### PR TITLE
OCCT 8 feature gallery and rendering upgrade

### DIFF
--- a/Sources/OCCTSwiftMetalDemo/CADFileLoader.swift
+++ b/Sources/OCCTSwiftMetalDemo/CADFileLoader.swift
@@ -184,15 +184,17 @@ enum CADFileLoader {
 
     /// Converts an OCCTSwift Shape to a ViewportBody and optional metadata.
     /// - Parameter stl: If true, uses coarser deflection suitable for pre-tessellated STL data
+    /// - Parameter deflection: Custom linear deflection override. Lower = smoother (default 0.1, STL uses 1.0).
     static func shapeToBodyAndMetadata(
         _ shape: Shape,
         id bodyID: String,
         color rgba: SIMD4<Float>,
-        stl: Bool = false
+        stl: Bool = false,
+        deflection customDeflection: Double? = nil
     ) -> (ViewportBody?, CADBodyMetadata?) {
         // STL files are already tessellated; use a large deflection so the
         // mesher preserves the existing triangulation rather than re-meshing.
-        let deflection: Double = stl ? 1.0 : 0.1
+        let deflection: Double = customDeflection ?? (stl ? 1.0 : 0.1)
         // Extract mesh with face indices
         guard let mesh = shape.mesh(linearDeflection: deflection) else {
             // Edge-only body — try to get edge polylines

--- a/Sources/OCCTSwiftMetalDemo/CADFileLoader.swift
+++ b/Sources/OCCTSwiftMetalDemo/CADFileLoader.swift
@@ -126,13 +126,32 @@ enum CADFileLoader {
     // MARK: - STL Loading
 
     private static func loadSTL(from url: URL) throws -> CADLoadResult {
-        let shape = try Shape.loadSTLRobust(from: url)
+        // Try plain load first — it preserves the original triangulation as-is.
+        // loadSTLRobust sews + MakeSolid which can lose geometry when a compound
+        // has multiple disconnected shells (only the first shell becomes a solid).
+        let shape = try Shape.loadSTL(from: url)
+
+        // For STL files the shape is typically a compound of triangulated faces.
+        // The existing mesh() call via BRepMesh + TopExp_Explorer(FACE) will
+        // pick up all faces in the compound — no re-meshing needed since the
+        // STL triangulation is already stored on each face.
+        //
+        // Use a coarser linearDeflection for STL (already tessellated) to avoid
+        // the mesher discarding pre-existing triangulations on large-coordinate models.
         let bodyID = "stl-0"
         let color = SIMD4<Float>(0.7, 0.7, 0.7, 1.0)
 
-        let (body, meta) = shapeToBodyAndMetadata(shape, id: bodyID, color: color)
+        let (body, meta) = shapeToBodyAndMetadata(shape, id: bodyID, color: color, stl: true)
         guard let body else {
-            return CADLoadResult(bodies: [], metadata: [:], shapes: [shape])
+            // If plain load produced no mesh, try robust as fallback
+            let robust = try Shape.loadSTLRobust(from: url)
+            let (body2, meta2) = shapeToBodyAndMetadata(robust, id: bodyID, color: color)
+            guard let body2 else {
+                return CADLoadResult(bodies: [], metadata: [:], shapes: [robust])
+            }
+            var metadata: [String: CADBodyMetadata] = [:]
+            if let meta2 { metadata[bodyID] = meta2 }
+            return CADLoadResult(bodies: [body2], metadata: metadata, shapes: [robust])
         }
 
         var metadata: [String: CADBodyMetadata] = [:]
@@ -164,13 +183,18 @@ enum CADFileLoader {
     // MARK: - Shape → Body Conversion
 
     /// Converts an OCCTSwift Shape to a ViewportBody and optional metadata.
+    /// - Parameter stl: If true, uses coarser deflection suitable for pre-tessellated STL data
     static func shapeToBodyAndMetadata(
         _ shape: Shape,
         id bodyID: String,
-        color rgba: SIMD4<Float>
+        color rgba: SIMD4<Float>,
+        stl: Bool = false
     ) -> (ViewportBody?, CADBodyMetadata?) {
+        // STL files are already tessellated; use a large deflection so the
+        // mesher preserves the existing triangulation rather than re-meshing.
+        let deflection: Double = stl ? 1.0 : 0.1
         // Extract mesh with face indices
-        guard let mesh = shape.mesh(linearDeflection: 0.1) else {
+        guard let mesh = shape.mesh(linearDeflection: deflection) else {
             // Edge-only body — try to get edge polylines
             let edgePolylines = extractEdgePolylines(from: shape)
             if !edgePolylines.isEmpty {

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -1789,120 +1789,170 @@ enum OCCT8Gallery {
         )
     }
 
-    // MARK: - v0.38: OBB, Fuse-and-Blend, Evolving Fillet
+    // MARK: - v0.38: Oriented Bounding Box
 
-    /// Demonstrates oriented bounding box, fuse-and-blend, and evolving fillet.
-    static func obbAndBlend() -> Curve2DGallery.GalleryResult {
+    /// Shows AABB vs OBB on the same shape — OBB fits tighter on rotated geometry.
+    static func orientedBoundingBox() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
 
-        // Oriented Bounding Box on a rotated shape
-        if let box = Shape.box(width: 4, height: 2, depth: 1),
-           let rotated = box.rotated(axis: SIMD3(0, 0, 1), angle: .pi / 6) {
+        // Build an L-shaped part and rotate it so AABB wastes space but OBB fits tight
+        if let arm1 = Shape.box(width: 6, height: 1, depth: 1),
+           let arm2 = Shape.box(width: 1, height: 4, depth: 1)?.translated(by: SIMD3(2.5, 2.5, 0)),
+           let lShape = arm1.union(with: arm2),
+           let rotated = lShape.rotated(axis: SIMD3(0, 0, 1), angle: .pi / 5) {
 
+            // The solid shape
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                rotated, id: "obb-shape", color: SIMD4(0.3, 0.7, 1.0, 0.8)
+                rotated, id: "obb-shape", color: SIMD4(0.5, 0.7, 0.9, 1.0)
             )
             if let body { bodies.append(body) }
 
-            // Show OBB as wireframe
+            // AABB — axis-aligned, wastes space on rotated shapes
+            if let bb = body?.boundingBox {
+                let lo = bb.min
+                let hi = bb.max
+                let c = [
+                    SIMD3(lo.x, lo.y, lo.z), SIMD3(hi.x, lo.y, lo.z),
+                    SIMD3(lo.x, hi.y, lo.z), SIMD3(hi.x, hi.y, lo.z),
+                    SIMD3(lo.x, lo.y, hi.z), SIMD3(hi.x, lo.y, hi.z),
+                    SIMD3(lo.x, hi.y, hi.z), SIMD3(hi.x, hi.y, hi.z)
+                ]
+                let aabbEdges: [[SIMD3<Float>]] = [
+                    [c[0], c[1]], [c[1], c[3]], [c[3], c[2]], [c[2], c[0]],
+                    [c[4], c[5]], [c[5], c[7]], [c[7], c[6]], [c[6], c[4]],
+                    [c[0], c[4]], [c[1], c[5]], [c[2], c[6]], [c[3], c[7]]
+                ]
+                bodies.append(ViewportBody(id: "obb-aabb", vertexData: [], indices: [],
+                                           edges: aabbEdges,
+                                           color: SIMD4(1.0, 0.3, 0.3, 1.0)))
+            }
+
+            // OBB — oriented, fits tighter
             if let corners = rotated.orientedBoundingBoxCorners(optimal: true) {
                 let fc = corners.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
                 if fc.count == 8 {
-                    // 8 corners: draw 12 edges of the box
-                    let edges: [[SIMD3<Float>]] = [
+                    let obbEdges: [[SIMD3<Float>]] = [
                         [fc[0], fc[1]], [fc[1], fc[3]], [fc[3], fc[2]], [fc[2], fc[0]],
                         [fc[4], fc[5]], [fc[5], fc[7]], [fc[7], fc[6]], [fc[6], fc[4]],
                         [fc[0], fc[4]], [fc[1], fc[5]], [fc[2], fc[6]], [fc[3], fc[7]]
                     ]
-                    bodies.append(ViewportBody(id: "obb-box", vertexData: [], indices: [], edges: edges,
-                                               color: SIMD4(1.0, 0.8, 0.0, 1.0)))
+                    bodies.append(ViewportBody(id: "obb-tight", vertexData: [], indices: [],
+                                               edges: obbEdges,
+                                               color: SIMD4(0.2, 1.0, 0.3, 1.0)))
                 }
-            }
-        }
-
-        // Fuse and Blend: union two shapes with automatic fillet at intersection
-        // Cylinder passes cleanly through the box center for reliable intersection edges
-        if let box = Shape.box(width: 4, height: 4, depth: 4),
-           let cyl = Shape.cylinder(radius: 1.0, height: 8)?.translated(by: SIMD3(0, -4, 0)) {
-
-            var fuseBlendOk = false
-            // Try fuse-and-blend with a conservative radius
-            if let blended = box.fusedAndBlended(with: cyl, radius: 0.15) {
-                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    blended, id: "blend-fuse", color: SIMD4(0.3, 0.9, 0.4, 0.9)
-                )
-                if var body {
-                    offsetBody(&body, dx: 9, dy: 0, dz: 0)
-                    bodies.append(body)
-                    fuseBlendOk = true
-                }
-            }
-
-            // Fallback: plain fuse if blend fails
-            if !fuseBlendOk, let fused = box.union(with: cyl) {
-                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    fused, id: "blend-fuse-fallback", color: SIMD4(0.3, 0.9, 0.4, 0.9)
-                )
-                if var body {
-                    offsetBody(&body, dx: 9, dy: 0, dz: 0)
-                    bodies.append(body)
-                }
-            }
-
-            // Cut and blend
-            var cutBlendOk = false
-            if let blended = box.cutAndBlended(with: cyl, radius: 0.15) {
-                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    blended, id: "blend-cut", color: SIMD4(0.9, 0.5, 0.3, 0.9)
-                )
-                if var body {
-                    offsetBody(&body, dx: 18, dy: 0, dz: 0)
-                    bodies.append(body)
-                    cutBlendOk = true
-                }
-            }
-
-            // Fallback: plain cut
-            if !cutBlendOk, let cut = box.subtracting(cyl) {
-                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    cut, id: "blend-cut-fallback", color: SIMD4(0.9, 0.5, 0.3, 0.9)
-                )
-                if var body {
-                    offsetBody(&body, dx: 18, dy: 0, dz: 0)
-                    bodies.append(body)
-                }
-            }
-        }
-
-        // Per-face variable offset
-        if let box = Shape.box(width: 3, height: 3, depth: 3) {
-            // Offset different faces by different amounts
-            if let varOffset = box.offsetPerFace(
-                defaultOffset: 0.2,
-                faceOffsets: [1: 0.8, 3: 0.5]
-            ) {
-                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    varOffset, id: "varoff", color: SIMD4(0.8, 0.4, 0.8, 0.9)
-                )
-                if var body {
-                    offsetBody(&body, dx: 0, dy: 8, dz: 0)
-                    bodies.append(body)
-                }
-            }
-
-            // Show original for reference
-            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                box, id: "varoff-orig", color: SIMD4(0.6, 0.6, 0.6, 0.3)
-            )
-            if var body {
-                offsetBody(&body, dx: 0, dy: 8, dz: 0)
-                bodies.append(body)
             }
         }
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.38: OBB (yellow wireframe), fuse+blend (green), cut+blend (orange), variable offset (purple)"
+            description: "Oriented bounding box: red = axis-aligned (loose), green = oriented (tight fit)"
+        )
+    }
+
+    // MARK: - v0.38: Fuse & Blend
+
+    /// Boolean union + automatic fillet at intersection vs plain union.
+    static func fuseAndBlend() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        if let box = Shape.box(width: 4, height: 4, depth: 4),
+           let cyl = Shape.cylinder(radius: 1.0, height: 8)?.translated(by: SIMD3(0, -4, 0)) {
+
+            // Left: plain union (sharp edges at intersection)
+            if let plain = box.union(with: cyl) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    plain, id: "fb-plain", color: SIMD4(0.6, 0.6, 0.6, 0.9)
+                )
+                if let body { bodies.append(body) }
+            }
+
+            // Right: fuse-and-blend (auto-filleted intersection edges)
+            if let blended = box.fusedAndBlended(with: cyl, radius: 0.15) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    blended, id: "fb-blended", color: SIMD4(0.3, 0.7, 1.0, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 9, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Far right: cut-and-blend (hole with filleted edges)
+            if let cut = box.cutAndBlended(with: cyl, radius: 0.15) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    cut, id: "fb-cutblend", color: SIMD4(0.9, 0.5, 0.3, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 18, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Left: plain union (sharp). Center: fuse+blend (filleted). Right: cut+blend (filleted hole)."
+        )
+    }
+
+    // MARK: - v0.38: Per-Face Variable Offset
+
+    /// Offsets each face of a box by a different amount.
+    static func variableOffset() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        if let box = Shape.box(width: 3, height: 3, depth: 3) {
+            // Original box (transparent)
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "vo-orig", color: SIMD4(0.6, 0.6, 0.6, 0.3)
+            )
+            if let orig { bodies.append(orig) }
+
+            // Uniform offset for comparison
+            if let uniform = box.offset(by: 0.3) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    uniform, id: "vo-uniform", color: SIMD4(0.3, 0.7, 1.0, 0.6)
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+                // Show original at same position
+                let (ref, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box, id: "vo-ref1", color: SIMD4(0.6, 0.6, 0.6, 0.3)
+                )
+                if var ref {
+                    offsetBody(&ref, dx: 7, dy: 0, dz: 0)
+                    bodies.append(ref)
+                }
+            }
+
+            // Per-face variable offset — some faces grow more than others
+            if let variable = box.offsetPerFace(
+                defaultOffset: 0.1,
+                faceOffsets: [1: 0.8, 3: 0.5]
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    variable, id: "vo-variable", color: SIMD4(0.9, 0.5, 0.3, 0.6)
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+                // Show original at same position
+                let (ref, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box, id: "vo-ref2", color: SIMD4(0.6, 0.6, 0.6, 0.3)
+                )
+                if var ref {
+                    offsetBody(&ref, dx: 14, dy: 0, dz: 0)
+                    bodies.append(ref)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Left: original. Center: uniform offset. Right: per-face variable offset (some faces thicker)."
         )
     }
 

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -738,6 +738,242 @@ enum OCCT8Gallery {
         )
     }
 
+    // MARK: - v0.31: Quasi-Uniform Curve Sampling
+
+    /// Compares uniform vs quasi-uniform (arc-length) sampling on curves.
+    static func quasiUniformSampling() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Create a BSpline curve with varying curvature
+        if let curve = Curve3D.bezier(poles: [
+            SIMD3(0, 0, 0), SIMD3(2, 5, 0), SIMD3(5, -3, 2),
+            SIMD3(8, 4, 1), SIMD3(12, 0, 0), SIMD3(15, 2, -1)
+        ]) {
+            // Draw the full curve
+            let fullParams = uniformParameters(curve: curve, count: 200)
+            let fullPts = curve.evaluateGrid(fullParams)
+            let floatFull = fullPts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+            bodies.append(ViewportBody(id: "qu-curve", vertexData: [], indices: [], edges: [floatFull],
+                                       color: SIMD4(0.5, 0.5, 0.5, 0.5)))
+
+            // Uniform parametric sampling (20 points) — clustered in low-curvature areas
+            let uniParams = uniformParameters(curve: curve, count: 20)
+            let uniPts = curve.evaluateGrid(uniParams)
+            for (i, pt) in uniPts.enumerated() {
+                bodies.append(makeMarker(
+                    at: SIMD3<Float>(Float(pt.x), Float(pt.y), Float(pt.z)),
+                    radius: 0.15, id: "qu-uni-\(i)",
+                    color: SIMD4(1.0, 0.3, 0.3, 1.0)
+                ))
+            }
+
+            // Quasi-uniform arc-length sampling (20 points) — evenly spaced along curve
+            let quParams = curve.quasiUniformParameters(count: 20)
+            let quPts = curve.evaluateGrid(quParams)
+            for (i, pt) in quPts.enumerated() {
+                bodies.append(makeMarker(
+                    at: SIMD3<Float>(Float(pt.x), Float(pt.y) - 8, Float(pt.z)),
+                    radius: 0.15, id: "qu-arc-\(i)",
+                    color: SIMD4(0.3, 1.0, 0.3, 1.0)
+                ))
+            }
+
+            // Draw the offset copy for arc-length sampling
+            let offsetFull = fullPts.map { SIMD3<Float>(Float($0.x), Float($0.y) - 8, Float($0.z)) }
+            bodies.append(ViewportBody(id: "qu-curve2", vertexData: [], indices: [], edges: [offsetFull],
+                                       color: SIMD4(0.5, 0.5, 0.5, 0.5)))
+
+            // Deflection-based sampling
+            let deflPts = curve.quasiUniformDeflectionPoints(deflection: 0.5)
+            for (i, pt) in deflPts.enumerated() {
+                bodies.append(makeMarker(
+                    at: SIMD3<Float>(Float(pt.x), Float(pt.y) - 16, Float(pt.z)),
+                    radius: 0.12, id: "qu-defl-\(i)",
+                    color: SIMD4(0.3, 0.5, 1.0, 1.0)
+                ))
+            }
+            let offsetFull2 = fullPts.map { SIMD3<Float>(Float($0.x), Float($0.y) - 16, Float($0.z)) }
+            bodies.append(ViewportBody(id: "qu-curve3", vertexData: [], indices: [], edges: [offsetFull2],
+                                       color: SIMD4(0.5, 0.5, 0.5, 0.5)))
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Sampling: uniform-param (red, top) vs arc-length (green, mid) vs deflection (blue, bottom)"
+        )
+    }
+
+    // MARK: - v0.31: Bezier Surface Fill
+
+    /// Creates surfaces from boundary curves using different fill styles.
+    static func bezierSurfaceFill() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Define 4 boundary curves forming a twisted quad
+        guard let c1 = Curve3D.bezier(poles: [SIMD3(0, 0, 0), SIMD3(3, 0, 1), SIMD3(6, 0, 0)]),
+              let c2 = Curve3D.bezier(poles: [SIMD3(6, 0, 0), SIMD3(6, 3, 2), SIMD3(6, 6, 0)]),
+              let c3 = Curve3D.bezier(poles: [SIMD3(6, 6, 0), SIMD3(3, 6, -1), SIMD3(0, 6, 0)]),
+              let c4 = Curve3D.bezier(poles: [SIMD3(0, 6, 0), SIMD3(0, 3, 1.5), SIMD3(0, 0, 0)])
+        else {
+            return Curve2DGallery.GalleryResult(bodies: bodies, description: "Curve creation failed")
+        }
+
+        // Draw boundary curves
+        for (i, curve) in [c1, c2, c3, c4].enumerated() {
+            let params = uniformParameters(curve: curve, count: 50)
+            let pts = curve.evaluateGrid(params)
+            let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+            bodies.append(ViewportBody(id: "bf-edge-\(i)", vertexData: [], indices: [], edges: [floatPts],
+                                       color: SIMD4(1.0, 1.0, 1.0, 1.0)))
+        }
+
+        // Stretch fill
+        if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .stretch),
+           let shell = Shape.shell(from: surf) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                shell, id: "bf-stretch", color: SIMD4(0.3, 0.6, 1.0, 0.8)
+            )
+            if let body { bodies.append(body) }
+        }
+
+        // Coons fill — offset right
+        if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .coons),
+           let shell = Shape.shell(from: surf) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                shell, id: "bf-coons", color: SIMD4(0.3, 0.9, 0.4, 0.8)
+            )
+            if var body {
+                offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        // Curved fill — offset further right
+        if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .curved),
+           let shell = Shape.shell(from: surf) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                shell, id: "bf-curved", color: SIMD4(0.9, 0.5, 0.3, 0.8)
+            )
+            if var body {
+                offsetBody(&body, dx: 20, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Bezier fill: stretch (blue), coons (green), curved (orange). Same boundary, 3 styles."
+        )
+    }
+
+    // MARK: - v0.31: Revolution from Curve
+
+    /// Creates solids of revolution from different meridian curves.
+    static func revolutionDemo() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Wine glass profile: BSpline meridian
+        if let profile = Curve3D.bezier(poles: [
+            SIMD3(0.5, 0, 0), SIMD3(1.5, 0, 0), SIMD3(0.3, 0, 2),
+            SIMD3(0.2, 0, 3), SIMD3(0.8, 0, 4), SIMD3(1.5, 0, 4.5)
+        ]) {
+            if let glass = Shape.revolution(meridian: profile) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    glass, id: "rev-glass", color: SIMD4(0.4, 0.7, 1.0, 0.8)
+                )
+                if let body { bodies.append(body) }
+            }
+
+            // Show the meridian curve
+            let params = uniformParameters(curve: profile, count: 100)
+            let pts = profile.evaluateGrid(params)
+            let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+            bodies.append(ViewportBody(id: "rev-meridian1", vertexData: [], indices: [], edges: [floatPts],
+                                       color: SIMD4(1.0, 1.0, 0.0, 1.0)))
+        }
+
+        // Vase profile
+        if let profile = Curve3D.bezier(poles: [
+            SIMD3(1.0, 0, 0), SIMD3(2.0, 0, 1), SIMD3(0.8, 0, 3),
+            SIMD3(1.5, 0, 5), SIMD3(1.2, 0, 6)
+        ]) {
+            if let vase = Shape.revolution(meridian: profile) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    vase, id: "rev-vase", color: SIMD4(0.9, 0.5, 0.3, 0.8)
+                )
+                if var body {
+                    offsetBody(&body, dx: 8, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Partial revolution (half turn) of a circle arc — creates a dome
+        if let arc = Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 1)) {
+            if let half = Shape.revolution(
+                meridian: arc,
+                axisOrigin: SIMD3(-6, 0, 0),
+                axisDirection: SIMD3(0, 0, 1),
+                angle: .pi
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    half, id: "rev-half", color: SIMD4(0.5, 0.9, 0.5, 0.8)
+                )
+                if var body {
+                    offsetBody(&body, dx: -6, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Revolution from curves: wine glass (blue), vase (orange), half-turn (green)"
+        )
+    }
+
+    // MARK: - v0.31: Linear Rib Feature
+
+    /// Adds reinforcing ribs to a base shape.
+    static func linearRibDemo() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Base plate
+        if let plate = Shape.box(width: 10, height: 2, depth: 8) {
+            // Show original
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                plate, id: "rib-base", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let body { bodies.append(body) }
+
+            // Add a rib profile along the top face
+            if let ribProfile = Wire.line(
+                from: SIMD3(1, 2, 1),
+                to: SIMD3(9, 2, 1)
+            ) {
+                if let ribbed = plate.addingLinearRib(
+                    profile: ribProfile,
+                    direction: SIMD3(0, 0, 1),
+                    draftDirection: SIMD3(0, 1, 0),
+                    fuse: true
+                ) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        ribbed, id: "rib-result", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                        bodies.append(body)
+                    }
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.31 Linear rib: base plate (gray) → with rib (blue)"
+        )
+    }
+
     // MARK: - Helpers
 
     private static func uniformParameters(curve: Curve3D, count: Int) -> [Double] {

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -2730,6 +2730,499 @@ enum OCCT8Gallery {
         )
     }
 
+    // MARK: - v0.44: Surface Extrema, Ellipse Arcs, Edge Analysis, Bezier Convert
+
+    /// Demonstrates surface extrema, ellipse arcs, dihedral angles, Bezier conversion,
+    /// and curve-on-surface validation.
+    static func extremaAndArcs() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- Surface extrema: min distance between a sphere and a plane ---
+        if let sphereSurf = Surface.sphere(center: SIMD3(0, 0, 5), radius: 3),
+           let planeSurf = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) {
+            // Show the sphere shape
+            if let sphere = Shape.sphere(radius: 3)?
+                .translated(by: SIMD3(0, 0, 5)) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    sphere, id: "extrema-sphere", color: SIMD4(0.4, 0.6, 0.9, 0.6),
+                    deflection: 0.02
+                )
+                if let body { bodies.append(body) }
+            }
+            // Show a ground plane as a thin box
+            if let ground = Shape.box(width: 12, height: 12, depth: 0.1)?
+                .translated(by: SIMD3(-6, -6, -0.05)) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    ground, id: "extrema-plane", color: SIMD4(0.5, 0.7, 0.5, 0.5),
+                    deflection: 0.05
+                )
+                if let body { bodies.append(body) }
+            }
+            // Compute extrema
+            if let result = sphereSurf.extrema(to: planeSurf) {
+                let p1 = SIMD3<Float>(Float(result.point1.x), Float(result.point1.y), Float(result.point1.z))
+                let p2 = SIMD3<Float>(Float(result.point2.x), Float(result.point2.y), Float(result.point2.z))
+                // Distance line between closest points
+                bodies.append(ViewportBody(
+                    id: "extrema-line", vertexData: [], indices: [],
+                    edges: [[p1, p2]], color: SIMD4(1, 0.3, 0.3, 1)
+                ))
+                // Markers at closest points
+                bodies.append(makeMarker(at: p1, radius: 0.2, id: "extrema-p1",
+                                          color: SIMD4(1, 0.3, 0.3, 1)))
+                bodies.append(makeMarker(at: p2, radius: 0.2, id: "extrema-p2",
+                                          color: SIMD4(1, 0.3, 0.3, 1)))
+                descriptions.append(String(format: "Extrema: d=%.2f", result.distance))
+            }
+        }
+
+        // --- Ellipse arcs: quarter, half, and 3/4 arcs in different planes ---
+        let arcDefs: [(String, Double, Double, SIMD3<Double>, SIMD4<Float>, Float)] = [
+            ("quarter", 0, .pi / 2, SIMD3(0, 0, 1), SIMD4(0.9, 0.3, 0.3, 1), 0),
+            ("half", 0, .pi, SIMD3(0, 0, 1), SIMD4(0.3, 0.9, 0.3, 1), 12),
+            ("three-quarter", 0, 1.5 * .pi, SIMD3(0, 0, 1), SIMD4(0.3, 0.3, 0.9, 1), 24),
+        ]
+        for (label, startA, endA, normal, color, dx) in arcDefs {
+            if let arc = Curve3D.arcOfEllipse(
+                center: SIMD3(0, 0, 0), normal: normal,
+                majorRadius: 5, minorRadius: 3,
+                startAngle: startA, endAngle: endA
+            ) {
+                let params = uniformParameters(curve: arc, count: 60)
+                let pts = arc.evaluateGrid(params).map {
+                    SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z))
+                }
+                var body = polylineToBody(pts, id: "arc-\(label)", color: color)
+                offsetBody(&body, dx: dx + 18, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+        // Also show a full ellipse outline for reference
+        if let fullEllipse = Curve3D.arcOfEllipse(
+            center: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1),
+            majorRadius: 5, minorRadius: 3,
+            startAngle: 0, endAngle: 2 * .pi
+        ) {
+            let params = uniformParameters(curve: fullEllipse, count: 80)
+            let pts = fullEllipse.evaluateGrid(params).map {
+                SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z))
+            }
+            for dx: Float in [18, 30, 42] {
+                var body = polylineToBody(pts, id: "ellipse-ref-\(dx)",
+                                          color: SIMD4(0.4, 0.4, 0.4, 0.4))
+                offsetBody(&body, dx: dx, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+        descriptions.append("Ellipse arcs: 1/4, 1/2, 3/4")
+
+        // --- Edge adjacentFaces + dihedralAngle: color faces sharing an edge ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6) {
+            // Show the box semi-transparent
+            let (boxBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "dihedral-box", color: SIMD4(0.6, 0.6, 0.6, 0.3),
+                deflection: 0.02
+            )
+            if var boxBody {
+                offsetBody(&boxBody, dx: 0, dy: 16, dz: 0)
+                bodies.append(boxBody)
+            }
+
+            // Pick edge 0 and highlight its adjacent faces
+            if let edge0 = box.edge(at: 0),
+               let (face1, face2) = edge0.adjacentFaces(in: box) {
+                // Highlight face1 in red
+                let face1Shape = box.subShape(type: .face, index: face1.index)
+                if let f1s = face1Shape {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        f1s, id: "dihedral-f1", color: SIMD4(0.9, 0.3, 0.3, 0.8),
+                        deflection: 0.02
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 0, dy: 16, dz: 0)
+                        bodies.append(body)
+                    }
+                }
+                // Highlight face2 in blue
+                if let f2 = face2 {
+                    let face2Shape = box.subShape(type: .face, index: f2.index)
+                    if let f2s = face2Shape {
+                        let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                            f2s, id: "dihedral-f2", color: SIMD4(0.3, 0.3, 0.9, 0.8),
+                            deflection: 0.02
+                        )
+                        if var body {
+                            offsetBody(&body, dx: 0, dy: 16, dz: 0)
+                            bodies.append(body)
+                        }
+                    }
+
+                    // Show dihedral angle
+                    if let angle = edge0.dihedralAngle(between: face1, and: f2) {
+                        let degrees = angle * 180.0 / .pi
+                        descriptions.append(String(format: "Dihedral: %.0f°", degrees))
+                    }
+                }
+
+                // Show the edge itself as a bold line
+                let ep = edge0.endpoints
+                let start = SIMD3<Float>(Float(ep.start.x), Float(ep.start.y), Float(ep.start.z))
+                let end = SIMD3<Float>(Float(ep.end.x), Float(ep.end.y), Float(ep.end.z))
+                var edgeBody = ViewportBody(
+                    id: "dihedral-edge", vertexData: [], indices: [],
+                    edges: [[start, end]], color: SIMD4(1, 1, 0.3, 1)
+                )
+                offsetBody(&edgeBody, dx: 0, dy: 16, dz: 0)
+                bodies.append(edgeBody)
+            }
+
+            // Show all edges with dihedral angles — color by angle
+            let allEdges = box.edges()
+            var angleCount = 0
+            for (i, edge) in allEdges.enumerated() {
+                if let (f1, f2) = edge.adjacentFaces(in: box), let f2 = f2 {
+                    if let _ = edge.dihedralAngle(between: f1, and: f2) {
+                        angleCount += 1
+                    }
+                }
+                // Draw each edge
+                let ep = edge.endpoints
+                let s = SIMD3<Float>(Float(ep.start.x), Float(ep.start.y), Float(ep.start.z))
+                let e = SIMD3<Float>(Float(ep.end.x), Float(ep.end.y), Float(ep.end.z))
+                var eb = ViewportBody(
+                    id: "dihedral-edge-\(i)", vertexData: [], indices: [],
+                    edges: [[s, e]], color: SIMD4(0.9, 0.9, 0.3, 1)
+                )
+                offsetBody(&eb, dx: 10, dy: 16, dz: 0)
+                bodies.append(eb)
+            }
+            descriptions.append("\(angleCount)/\(allEdges.count) edges have angles")
+        }
+
+        // --- convertedToBezier: cylinder before/after ---
+        if let cyl = Shape.cylinder(radius: 3, height: 5) {
+            let origEdges = cyl.subShapeCount(ofType: .edge)
+            let origFaces = cyl.subShapeCount(ofType: .face)
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "bezier-orig", color: SIMD4(0.6, 0.6, 0.6, 0.6),
+                deflection: 0.02
+            )
+            if var orig {
+                offsetBody(&orig, dx: 0, dy: 30, dz: 0)
+                bodies.append(orig)
+            }
+
+            if let bezier = cyl.convertedToBezier {
+                let newEdges = bezier.subShapeCount(ofType: .edge)
+                let newFaces = bezier.subShapeCount(ofType: .face)
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    bezier, id: "bezier-result", color: SIMD4(0.3, 0.8, 0.6, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 12, dy: 30, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("Bezier: \(origFaces)F/\(origEdges)E → \(newFaces)F/\(newEdges)E")
+            }
+        }
+
+        // --- curveOnSurfaceCheck: validate a complex shape ---
+        if let torus = Shape.torus(majorRadius: 5, minorRadius: 2) {
+            if let check = torus.curveOnSurfaceCheck {
+                descriptions.append(String(format: "pcurve check: max dev=%.1e", check.maxDistance))
+            } else {
+                descriptions.append("pcurve check: n/a")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.44: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.45: N-Side Filling, Self-Intersection, Wire Ordering
+
+    /// Demonstrates FillingSurface, selfIntersection, and WireOrder.
+    static func fillingAndSelfIntersection() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- FillingSurface: fill a hole bounded by 4 edges with a raised interior point ---
+        if let box = Shape.box(width: 10, height: 10, depth: 0.1) {
+            let allEdges = box.edges()
+            // Use the first 4 edges (bottom face boundary)
+            if allEdges.count >= 4 {
+                let filling = FillingSurface()
+                for i in 0..<4 {
+                    filling.add(edge: allEdges[i], continuity: .c0)
+                }
+                // Add a raised interior point to make it interesting
+                filling.add(point: SIMD3(5, 5, 4))
+
+                if let face = filling.build() {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        face, id: "filling-face", color: SIMD4(0.3, 0.7, 0.9, 0.85),
+                        deflection: 0.02
+                    )
+                    if let body { bodies.append(body) }
+
+                    if let g0 = filling.g0Error {
+                        descriptions.append(String(format: "N-fill G0=%.1e", g0))
+                    } else {
+                        descriptions.append("N-fill: built")
+                    }
+                }
+            }
+        }
+
+        // Second filling: triangle from 3 wire edges
+        let triPts: [SIMD3<Double>] = [
+            SIMD3(0, 0, 0), SIMD3(8, 0, 0), SIMD3(4, 7, 0)
+        ]
+        if let triWire = Wire.polygon3D(triPts, closed: true) {
+            let triEdges = Shape.fromWire(triWire)?.edges() ?? []
+            if triEdges.count >= 3 {
+                let filling = FillingSurface()
+                for edge in triEdges {
+                    filling.add(edge: edge, continuity: .c0)
+                }
+                filling.add(point: SIMD3(4, 2.5, 3))
+
+                if let face = filling.build() {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        face, id: "filling-tri", color: SIMD4(0.9, 0.5, 0.3, 0.85),
+                        deflection: 0.02
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                        bodies.append(body)
+                    }
+                    descriptions.append("tri-fill")
+                }
+            }
+        }
+
+        // --- Self-intersection detection ---
+        // Clean box — should have no self-intersections
+        if let box = Shape.box(width: 5, height: 5, depth: 5) {
+            if let result = box.selfIntersection() {
+                descriptions.append("box SI: \(result.overlapCount)")
+            } else {
+                descriptions.append("box SI: n/a")
+            }
+
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "si-box", color: SIMD4(0.5, 0.8, 0.5, 0.7),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 14, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        // --- WireOrder: scramble edges and reorder them ---
+        // Define 4 edges of a square in scrambled order
+        let scrambled: [(start: SIMD3<Double>, end: SIMD3<Double>)] = [
+            (SIMD3(0, 0, 0), SIMD3(8, 0, 0)),       // edge 0: bottom
+            (SIMD3(8, 8, 0), SIMD3(0, 8, 0)),       // edge 1: top (reversed)
+            (SIMD3(0, 8, 0), SIMD3(0, 0, 0)),       // edge 2: left
+            (SIMD3(8, 0, 0), SIMD3(8, 8, 0)),       // edge 3: right
+        ]
+
+        // Show scrambled edges with numbered colors
+        let edgeColors: [SIMD4<Float>] = [
+            SIMD4(1, 0.3, 0.3, 1), SIMD4(0.3, 1, 0.3, 1),
+            SIMD4(0.3, 0.3, 1, 1), SIMD4(1, 1, 0.3, 1),
+        ]
+        for (i, edge) in scrambled.enumerated() {
+            let s = SIMD3<Float>(Float(edge.start.x), Float(edge.start.y), Float(edge.start.z))
+            let e = SIMD3<Float>(Float(edge.end.x), Float(edge.end.y), Float(edge.end.z))
+            var body = ViewportBody(
+                id: "wireorder-scrambled-\(i)", vertexData: [], indices: [],
+                edges: [[s, e]], color: edgeColors[i]
+            )
+            offsetBody(&body, dx: 14, dy: 14, dz: 0)
+            bodies.append(body)
+        }
+
+        if let order = WireOrder.analyze(edges: scrambled) {
+            let indices = order.orderedEdges.map {
+                "\($0.isReversed ? "-" : "")\($0.originalIndex)"
+            }
+            descriptions.append("WireOrder(\(order.status)): [\(indices.joined(separator: ","))]")
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.45: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.46: Edge Concavity, Local Prism, Volume Inertia
+
+    /// Demonstrates edgeConcavities, localPrism, volumeInertia, and surfaceInertia.
+    static func concavityAndInertia() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- Edge concavity: color box edges by convex/concave/tangent ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6) {
+            let (boxBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "concavity-box", color: SIMD4(0.6, 0.6, 0.6, 0.4),
+                deflection: 0.02
+            )
+            if let boxBody { bodies.append(boxBody) }
+
+            if let concavities = box.edgeConcavities() {
+                var convexCount = 0, concaveCount = 0, tangentCount = 0
+                for (edge, concavity) in concavities {
+                    let color: SIMD4<Float>
+                    switch concavity {
+                    case .convex:
+                        color = SIMD4(0.3, 0.9, 0.3, 1); convexCount += 1
+                    case .concave:
+                        color = SIMD4(0.9, 0.3, 0.3, 1); concaveCount += 1
+                    case .tangent:
+                        color = SIMD4(0.9, 0.9, 0.3, 1); tangentCount += 1
+                    }
+                    let ep = edge.endpoints
+                    let s = SIMD3<Float>(Float(ep.start.x), Float(ep.start.y), Float(ep.start.z))
+                    let e = SIMD3<Float>(Float(ep.end.x), Float(ep.end.y), Float(ep.end.z))
+                    bodies.append(ViewportBody(
+                        id: "concavity-e\(edge.index)", vertexData: [], indices: [],
+                        edges: [[s, e]], color: color
+                    ))
+                }
+                descriptions.append("Concavity: \(convexCount)cvx \(concaveCount)ccv \(tangentCount)tan")
+            }
+        }
+
+        // Filleted box — has tangent edges at the fillet-face transitions
+        if let box = Shape.box(width: 6, height: 6, depth: 6),
+           let filleted = box.filleted(radius: 1.0) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                filleted, id: "concavity-fillet", color: SIMD4(0.6, 0.6, 0.6, 0.4),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 12, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            if let concavities = filleted.edgeConcavities() {
+                var cvx = 0, ccv = 0, tan = 0
+                for (edge, concavity) in concavities {
+                    let color: SIMD4<Float>
+                    switch concavity {
+                    case .convex: color = SIMD4(0.3, 0.9, 0.3, 1); cvx += 1
+                    case .concave: color = SIMD4(0.9, 0.3, 0.3, 1); ccv += 1
+                    case .tangent: color = SIMD4(0.9, 0.9, 0.3, 1); tan += 1
+                    }
+                    let ep = edge.endpoints
+                    let s = SIMD3<Float>(Float(ep.start.x), Float(ep.start.y), Float(ep.start.z))
+                    let e = SIMD3<Float>(Float(ep.end.x), Float(ep.end.y), Float(ep.end.z))
+                    var eb = ViewportBody(
+                        id: "concavity-f-e\(edge.index)", vertexData: [], indices: [],
+                        edges: [[s, e]], color: color
+                    )
+                    offsetBody(&eb, dx: 12, dy: 0, dz: 0)
+                    bodies.append(eb)
+                }
+                descriptions.append("Filleted: \(cvx)cvx \(ccv)ccv \(tan)tan")
+            }
+        }
+
+        // --- Local prism: extrude a face profile ---
+        if let rectWire = Wire.rectangle(width: 4, height: 3),
+           let face = Shape.face(from: rectWire) {
+            // Simple upward prism
+            if let prism = face.localPrism(direction: SIMD3(0, 0, 6)) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    prism, id: "prism-simple", color: SIMD4(0.4, 0.6, 0.9, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 0, dy: 14, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Prism with translation (skewed)
+            if let prism = face.localPrism(direction: SIMD3(0, 0, 6),
+                                            translation: SIMD3(3, 2, 0)) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    prism, id: "prism-skewed", color: SIMD4(0.9, 0.5, 0.3, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 10, dy: 14, dz: 0)
+                    bodies.append(body)
+                }
+            }
+            descriptions.append("localPrism: straight + skewed")
+        }
+
+        // --- Volume inertia: box with principal axes visualization ---
+        if let box = Shape.box(width: 10, height: 6, depth: 4) {
+            let (boxBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "inertia-box", color: SIMD4(0.5, 0.7, 0.8, 0.6),
+                deflection: 0.02
+            )
+            if var boxBody {
+                offsetBody(&boxBody, dx: 0, dy: 28, dz: 0)
+                bodies.append(boxBody)
+            }
+
+            if let vi = box.volumeInertia {
+                let cm = SIMD3<Float>(Float(vi.centerOfMass.x), Float(vi.centerOfMass.y), Float(vi.centerOfMass.z))
+                // Center of mass marker
+                var marker = makeMarker(at: cm, radius: 0.3, id: "inertia-cm",
+                                         color: SIMD4(1, 1, 1, 1))
+                offsetBody(&marker, dx: 0, dy: 28, dz: 0)
+                bodies.append(marker)
+
+                // Principal axes as colored lines from center of mass
+                let axisColors: [SIMD4<Float>] = [
+                    SIMD4(1, 0.2, 0.2, 1), // axis 1 — red
+                    SIMD4(0.2, 1, 0.2, 1), // axis 2 — green
+                    SIMD4(0.2, 0.2, 1, 1), // axis 3 — blue
+                ]
+                let axes = [vi.principalAxes.0, vi.principalAxes.1, vi.principalAxes.2]
+                for (i, axis) in axes.enumerated() {
+                    let dir = SIMD3<Float>(Float(axis.x), Float(axis.y), Float(axis.z))
+                    let len = Float(vi.gyrationRadii[i]) * 0.5
+                    let start = cm - dir * len
+                    let end = cm + dir * len
+                    var axisBody = ViewportBody(
+                        id: "inertia-axis-\(i)", vertexData: [], indices: [],
+                        edges: [[start, end]], color: axisColors[i]
+                    )
+                    offsetBody(&axisBody, dx: 0, dy: 28, dz: 0)
+                    bodies.append(axisBody)
+                }
+
+                descriptions.append(String(format: "Vol=%.0f CM=(%.0f,%.0f,%.0f)",
+                    vi.volume, vi.centerOfMass.x, vi.centerOfMass.y, vi.centerOfMass.z))
+                descriptions.append(String(format: "Moments: %.0f/%.0f/%.0f",
+                    vi.principalMoments.x, vi.principalMoments.y, vi.principalMoments.z))
+            }
+
+            // Surface inertia too
+            if let si = box.surfaceInertia {
+                descriptions.append(String(format: "Area=%.0f", si.area))
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.46: " + descriptions.joined(separator: " | ")
+        )
+    }
+
     // MARK: - Helpers
 
     private static func uniformParameters(curve: Curve3D, count: Int) -> [Double] {

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -387,7 +387,364 @@ enum OCCT8Gallery {
         )
     }
 
+    // MARK: - v0.30: Non-Uniform Scaling & Offset
+
+    /// Demonstrates non-uniform scaling, simple offset, and fused edges.
+    static func transformOps() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Original box
+        if let box = Shape.box(width: 2, height: 2, depth: 2) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "xform-original", color: SIMD4(0.6, 0.6, 0.6, 0.5)
+            )
+            if let body { bodies.append(body) }
+
+            // Non-uniform scale: stretch X×3, Y×0.5, Z×1.5
+            if let scaled = box.nonUniformScaled(sx: 3, sy: 0.5, sz: 1.5) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    scaled, id: "xform-nuscale", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: 6, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Sphere with simple offset (inflation)
+        if let sphere = Shape.sphere(radius: 1.5) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sphere, id: "xform-sphere", color: SIMD4(0.6, 0.6, 0.6, 0.5)
+            )
+            if var body {
+                offsetBody(&body, dx: -6, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            if let inflated = sphere.simpleOffset(by: 0.8) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    inflated, id: "xform-offset", color: SIMD4(0.9, 0.5, 0.3, 0.7)
+                )
+                if var body {
+                    offsetBody(&body, dx: -6, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Cylinder with fused edges
+        if let cyl = Shape.cylinder(radius: 1, height: 3) {
+            // Boolean union to create extra edges, then fuse
+            if let box = Shape.box(width: 1.5, height: 1.5, depth: 4) {
+                if let fused = cyl.union(with: box) {
+                    let (body1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        fused, id: "xform-prefuse", color: SIMD4(0.7, 0.7, 0.7, 0.5)
+                    )
+                    if var body1 {
+                        offsetBody(&body1, dx: 0, dy: 6, dz: 0)
+                        bodies.append(body1)
+                    }
+
+                    if let cleaned = fused.fusedEdges() {
+                        let (body2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                            cleaned, id: "xform-fusededges", color: SIMD4(0.5, 0.9, 0.5, 1.0)
+                        )
+                        if var body2 {
+                            offsetBody(&body2, dx: 5, dy: 6, dz: 0)
+                            bodies.append(body2)
+                        }
+                    }
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.30: Non-uniform scale (blue), offset (orange), fused edges (green)"
+        )
+    }
+
+    // MARK: - v0.30: Shape Analysis & Canonical Recognition
+
+    /// Demonstrates shape contents census and canonical form recognition.
+    static func shapeAnalysis() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // Cylinder — should recognize as canonical cylinder
+        if let cyl = Shape.cylinder(radius: 2, height: 4) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "analysis-cyl", color: SIMD4(0.3, 0.6, 1.0, 1.0)
+            )
+            if let body { bodies.append(body) }
+
+            let c = cyl.contents
+            descriptions.append("Cyl: \(c.faces)F \(c.edges)E \(c.vertices)V")
+            if let canon = cyl.recognizeCanonical() {
+                descriptions.append("→ \(canon.type) r=\(String(format: "%.1f", canon.radius))")
+            }
+        }
+
+        // Sphere
+        if let sph = Shape.sphere(radius: 1.5) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sph, id: "analysis-sph", color: SIMD4(0.3, 0.9, 0.4, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: 6, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            let c = sph.contents
+            descriptions.append("Sph: \(c.faces)F \(c.edges)E")
+            if let canon = sph.recognizeCanonical() {
+                descriptions.append("→ \(canon.type) r=\(String(format: "%.1f", canon.radius))")
+            }
+        }
+
+        // Box — should recognize planes
+        if let box = Shape.box(width: 3, height: 2, depth: 2) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "analysis-box", color: SIMD4(0.9, 0.6, 0.3, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: -6, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            let c = box.contents
+            descriptions.append("Box: \(c.solids)S \(c.faces)F \(c.edges)E \(c.vertices)V")
+        }
+
+        // Cone
+        if let cone = Shape.cone(bottomRadius: 2, topRadius: 0.5, height: 3) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cone, id: "analysis-cone", color: SIMD4(0.8, 0.4, 0.8, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 6, dz: 0)
+                bodies.append(body)
+            }
+
+            let c = cone.contents
+            descriptions.append("Cone: \(c.faces)F \(c.edges)E")
+            if let canon = cone.recognizeCanonical() {
+                descriptions.append("→ \(canon.type)")
+            }
+        }
+
+        // Vertex primitive
+        if let vtx = Shape.vertex(at: SIMD3(3, 6, 1.5)) {
+            let c = vtx.contents
+            descriptions.append("Vertex: \(c.vertices)V")
+            // Visualize as marker
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(3, 6, 1.5),
+                radius: 0.2, id: "analysis-vtx",
+                color: SIMD4(1.0, 1.0, 0.0, 1.0)
+            ))
+        }
+
+        let desc = descriptions.joined(separator: " | ")
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.30 Analysis: \(desc)"
+        )
+    }
+
+    // MARK: - v0.30: Curve & Surface Intersections
+
+    /// Demonstrates curve-curve extrema, curve-surface intersection, surface-surface intersection.
+    static func intersectionAnalysis() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // -- Curve-curve extrema --
+        // Two skew lines in 3D
+        if let line1 = Curve3D.line(through: SIMD3(-5, 0, 0), direction: SIMD3(1, 0, 0)),
+           let line2 = Curve3D.line(through: SIMD3(0, -5, 2), direction: SIMD3(0, 1, 0)) {
+
+            // Visualize the lines
+            let l1pts: [SIMD3<Float>] = [SIMD3(-5, 0, 0), SIMD3(5, 0, 0)]
+            let l2pts: [SIMD3<Float>] = [SIMD3(0, -5, 2), SIMD3(0, 5, 2)]
+            bodies.append(ViewportBody(id: "ix-line1", vertexData: [], indices: [], edges: [l1pts],
+                                       color: SIMD4(0.3, 0.6, 1.0, 1.0)))
+            bodies.append(ViewportBody(id: "ix-line2", vertexData: [], indices: [], edges: [l2pts],
+                                       color: SIMD4(1.0, 0.5, 0.2, 1.0)))
+
+            if let dist = line1.minDistance(to: line2) {
+                let extrema = line1.extrema(with: line2)
+                for (i, ext) in extrema.enumerated() {
+                    let p1 = SIMD3<Float>(Float(ext.point1.x), Float(ext.point1.y), Float(ext.point1.z))
+                    let p2 = SIMD3<Float>(Float(ext.point2.x), Float(ext.point2.y), Float(ext.point2.z))
+                    bodies.append(makeMarker(at: p1, radius: 0.15, id: "ix-ext-p1-\(i)",
+                                             color: SIMD4(1.0, 0.2, 0.2, 1.0)))
+                    bodies.append(makeMarker(at: p2, radius: 0.15, id: "ix-ext-p2-\(i)",
+                                             color: SIMD4(0.2, 1.0, 0.2, 1.0)))
+                    // Connector line between closest points
+                    bodies.append(ViewportBody(id: "ix-ext-conn-\(i)", vertexData: [], indices: [], edges: [[p1, p2]],
+                                               color: SIMD4(1.0, 1.0, 0.0, 1.0)))
+                }
+                _ = dist  // used for the description
+            }
+        }
+
+        // -- Curve-surface intersection --
+        // Circle curve intersecting a plane
+        if let circle = Curve3D.circle(center: SIMD3(0, 0, 0), normal: SIMD3(1, 0, 1), radius: 3),
+           let plane = Surface.plane(origin: SIMD3(0, 0, 0), normal: SIMD3(0, 0, 1)) {
+
+            // Visualize the circle using evaluate
+            let cParams = uniformParameters(curve: circle, count: 80)
+            let pts = circle.evaluateGrid(cParams)
+            if !pts.isEmpty {
+                let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+                var closed = floatPts
+                if let first = closed.first { closed.append(first) }
+                bodies.append(ViewportBody(id: "ix-circle", vertexData: [], indices: [], edges: [closed],
+                                           color: SIMD4(0.5, 0.8, 1.0, 1.0)))
+            }
+
+            // Visualize the plane as a flat quad
+            let planeSize: Float = 5
+            let planeVerts: [SIMD3<Float>] = [
+                SIMD3(-planeSize, -planeSize, 0), SIMD3(planeSize, -planeSize, 0),
+                SIMD3(planeSize, planeSize, 0), SIMD3(-planeSize, planeSize, 0),
+                SIMD3(-planeSize, -planeSize, 0)
+            ]
+            bodies.append(ViewportBody(id: "ix-plane", vertexData: [], indices: [], edges: [planeVerts],
+                                       color: SIMD4(0.5, 0.5, 0.5, 0.3)))
+
+            let hits = circle.intersections(with: plane)
+            for (i, hit) in hits.enumerated() {
+                let p = SIMD3<Float>(Float(hit.point.x), Float(hit.point.y), Float(hit.point.z))
+                bodies.append(makeMarker(at: p, radius: 0.2, id: "ix-cs-hit-\(i)",
+                                         color: SIMD4(1.0, 0.3, 0.3, 1.0)))
+            }
+        }
+
+        // -- Surface-surface intersection --
+        // Cylinder intersecting a sphere
+        if let cylSurf = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 2),
+           let sphSurf = Surface.sphere(center: SIMD3(1, 0, 0), radius: 2.5) {
+
+            // Show the shapes for context
+            if let cylShape = Shape.cylinder(radius: 2, height: 4) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    cylShape, id: "ix-cyl-shape", color: SIMD4(0.3, 0.6, 1.0, 0.3)
+                )
+                if var body {
+                    offsetBody(&body, dx: 12, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+            if let sphShape = Shape.sphere(radius: 2.5) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    sphShape, id: "ix-sph-shape", color: SIMD4(0.3, 0.9, 0.4, 0.3)
+                )
+                if var body {
+                    offsetBody(&body, dx: 13, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            let ixCurves = cylSurf.intersections(with: sphSurf)
+            for (i, curve) in ixCurves.enumerated() {
+                let ssParams = uniformParameters(curve: curve, count: 100)
+                let pts = curve.evaluateGrid(ssParams)
+                if !pts.isEmpty {
+                    let floatPts = pts.map { SIMD3<Float>(Float($0.x) + 12, Float($0.y), Float($0.z)) }
+                    bodies.append(ViewportBody(id: "ix-ss-\(i)", vertexData: [], indices: [], edges: [floatPts],
+                                               color: SIMD4(1.0, 0.2, 0.2, 1.0)))
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.30 Intersections: curve-curve extrema, curve-surface hits, surface-surface curves"
+        )
+    }
+
+    // MARK: - v0.30: Volume & Connected Shapes
+
+    /// Demonstrates makeVolume from faces and makeConnected.
+    static func volumeOps() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Make a volume from overlapping boxes
+        if let box1 = Shape.box(width: 3, height: 3, depth: 3),
+           let box2 = Shape.box(width: 3, height: 3, depth: 3)?.translated(by: SIMD3(1.5, 1.5, 0)) {
+
+            // Show originals semi-transparent
+            let (b1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box1, id: "vol-box1", color: SIMD4(0.3, 0.6, 1.0, 0.3)
+            )
+            if let b1 { bodies.append(b1) }
+            let (b2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box2, id: "vol-box2", color: SIMD4(1.0, 0.5, 0.2, 0.3)
+            )
+            if let b2 { bodies.append(b2) }
+
+            // Volume from faces
+            if let volume = Shape.makeVolume(from: [box1, box2]) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    volume, id: "vol-result", color: SIMD4(0.5, 0.9, 0.5, 0.8)
+                )
+                if var body {
+                    offsetBody(&body, dx: 8, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+
+                let c = volume.contents
+                bodies.append(contentsOf: []) // no-op; just use c below
+                _ = c // description will reference it
+            }
+        }
+
+        // MakeConnected — two adjacent boxes sharing a face
+        if let box1 = Shape.box(width: 2, height: 2, depth: 2),
+           let box2 = Shape.box(width: 2, height: 2, depth: 2)?.translated(by: SIMD3(2, 0, 0)) {
+
+            let (b1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box1, id: "conn-box1", color: SIMD4(0.7, 0.3, 0.8, 0.5)
+            )
+            if var b1 {
+                offsetBody(&b1, dx: 0, dy: 8, dz: 0)
+                bodies.append(b1)
+            }
+            let (b2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box2, id: "conn-box2", color: SIMD4(0.3, 0.8, 0.7, 0.5)
+            )
+            if var b2 {
+                offsetBody(&b2, dx: 0, dy: 8, dz: 0)
+                bodies.append(b2)
+            }
+
+            if let connected = Shape.makeConnected([box1, box2]) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    connected, id: "conn-result", color: SIMD4(0.9, 0.8, 0.3, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: 8, dy: 8, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.30: makeVolume (green) from overlapping boxes, makeConnected (yellow)"
+        )
+    }
+
     // MARK: - Helpers
+
+    private static func uniformParameters(curve: Curve3D, count: Int) -> [Double] {
+        let d = curve.domain
+        let step = (d.upperBound - d.lowerBound) / Double(count)
+        return (0...count).map { d.lowerBound + Double($0) * step }
+    }
 
     private static func wireToBody(
         _ wire: Wire,

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -2250,6 +2250,74 @@ enum OCCT8Gallery {
             }
         }
 
+        // SubShape API: extract individual faces, count sub-shapes, remove a face
+        if let box = Shape.box(width: 3, height: 3, depth: 3) {
+            // Fillet the box first for a more interesting shape
+            let target = box.filleted(radius: 0.4) ?? box
+
+            let faceCount = target.subShapeCount(ofType: .face)
+            let edgeCount = target.subShapeCount(ofType: .edge)
+            let vertexCount = target.subShapeCount(ofType: .vertex)
+            descriptions.append("SubShape: \(faceCount)F \(edgeCount)E \(vertexCount)V")
+
+            // Show the original filleted box (semi-transparent)
+            let (origBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                target, id: "subshape-orig", color: SIMD4(0.6, 0.6, 0.6, 0.3),
+                deflection: 0.02
+            )
+            if var origBody {
+                offsetBody(&origBody, dx: 0, dy: 20, dz: 0)
+                bodies.append(origBody)
+            }
+
+            // Extract face 0 and remove it
+            if let face0 = target.subShape(type: .face, index: 0) {
+                let (faceBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    face0, id: "subshape-face0", color: SIMD4(1.0, 0.3, 0.3, 0.9),
+                    deflection: 0.02
+                )
+                if var faceBody {
+                    offsetBody(&faceBody, dx: 0, dy: 20, dz: 0)
+                    bodies.append(faceBody)
+                }
+
+                // Remove that face
+                if let removed = target.removingSubShapes([face0]) {
+                    let removedFaceCount = removed.subShapeCount(ofType: .face)
+                    let (removedBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        removed, id: "subshape-removed", color: SIMD4(0.3, 0.8, 0.5, 0.9),
+                        deflection: 0.02
+                    )
+                    if var removedBody {
+                        offsetBody(&removedBody, dx: 7, dy: 20, dz: 0)
+                        bodies.append(removedBody)
+                    }
+                    descriptions.append("Removed 1 face: \(faceCount)→\(removedFaceCount)F")
+                }
+            }
+
+            // Visualize all faces individually with per-face colors
+            let allFaces = target.subShapes(ofType: .face)
+            let faceColors: [SIMD4<Float>] = [
+                SIMD4(0.9, 0.3, 0.3, 0.8), SIMD4(0.3, 0.9, 0.3, 0.8),
+                SIMD4(0.3, 0.3, 0.9, 0.8), SIMD4(0.9, 0.9, 0.3, 0.8),
+                SIMD4(0.9, 0.3, 0.9, 0.8), SIMD4(0.3, 0.9, 0.9, 0.8),
+                SIMD4(0.9, 0.6, 0.3, 0.8), SIMD4(0.6, 0.3, 0.9, 0.8),
+            ]
+            for (i, face) in allFaces.enumerated() {
+                let color = faceColors[i % faceColors.count]
+                let (faceBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    face, id: "subshape-all-\(i)", color: color,
+                    deflection: 0.02
+                )
+                if var faceBody {
+                    offsetBody(&faceBody, dx: 14, dy: 20, dz: 0)
+                    bodies.append(faceBody)
+                }
+            }
+            descriptions.append("All \(allFaces.count) faces colored")
+        }
+
         // Closed edge splitting
         if let cyl = Shape.cylinder(radius: 1.5, height: 3) {
             let origContents = cyl.contents

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -755,7 +755,7 @@ enum OCCT8Gallery {
         var polylines: [[SIMD3<Float>]] = []
 
         for i in 0..<edgeCount {
-            if let pts = wire.orderedEdgePoints(at: i) {
+            if let pts = wire.orderedEdgePoints(at: i, maxPoints: 10000) {
                 let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
                 if floatPts.count >= 2 {
                     polylines.append(floatPts)

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -1821,12 +1821,27 @@ enum OCCT8Gallery {
         }
 
         // Fuse and Blend: union two shapes with automatic fillet at intersection
-        if let box = Shape.box(width: 3, height: 3, depth: 3),
-           let cyl = Shape.cylinder(radius: 1.2, height: 5)?.translated(by: SIMD3(1.5, 0, -1)) {
+        // Cylinder passes cleanly through the box center for reliable intersection edges
+        if let box = Shape.box(width: 4, height: 4, depth: 4),
+           let cyl = Shape.cylinder(radius: 1.0, height: 8)?.translated(by: SIMD3(0, -4, 0)) {
 
-            if let blended = box.fusedAndBlended(with: cyl, radius: 0.3) {
+            var fuseBlendOk = false
+            // Try fuse-and-blend with a conservative radius
+            if let blended = box.fusedAndBlended(with: cyl, radius: 0.15) {
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                     blended, id: "blend-fuse", color: SIMD4(0.3, 0.9, 0.4, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 9, dy: 0, dz: 0)
+                    bodies.append(body)
+                    fuseBlendOk = true
+                }
+            }
+
+            // Fallback: plain fuse if blend fails
+            if !fuseBlendOk, let fused = box.union(with: cyl) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    fused, id: "blend-fuse-fallback", color: SIMD4(0.3, 0.9, 0.4, 0.9)
                 )
                 if var body {
                     offsetBody(&body, dx: 9, dy: 0, dz: 0)
@@ -1834,10 +1849,23 @@ enum OCCT8Gallery {
                 }
             }
 
-            // Cut and blend for comparison
-            if let blended = box.cutAndBlended(with: cyl, radius: 0.2) {
+            // Cut and blend
+            var cutBlendOk = false
+            if let blended = box.cutAndBlended(with: cyl, radius: 0.15) {
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                     blended, id: "blend-cut", color: SIMD4(0.9, 0.5, 0.3, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 18, dy: 0, dz: 0)
+                    bodies.append(body)
+                    cutBlendOk = true
+                }
+            }
+
+            // Fallback: plain cut
+            if !cutBlendOk, let cut = box.subtracting(cyl) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    cut, id: "blend-cut-fallback", color: SIMD4(0.9, 0.5, 0.3, 0.9)
                 )
                 if var body {
                     offsetBody(&body, dx: 18, dy: 0, dz: 0)

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -3382,6 +3382,333 @@ enum OCCT8Gallery {
         }
     }
 
+    // MARK: - v0.47: Local Revolution, Draft Prism & Validation
+
+    /// Local revolution, draft prism, constrained fill, and BRepCheck validation.
+    static func localOpsAndValidation() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- Local revolution: revolve a rectangular profile around Y axis ---
+        if let rectWire = Wire.rectangle(width: 2, height: 1),
+           let face = Shape.face(from: rectWire) {
+            // Move profile away from axis so revolution creates a ring
+            let profile = face.translated(by: SIMD3(3, 0, 0))
+            if let revolved = profile?.localRevolution(
+                axisOrigin: SIMD3(0, 0, 0),
+                axisDirection: SIMD3(0, 1, 0),
+                angle: .pi * 1.5 // 270 degrees
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    revolved, id: "local-revol", color: SIMD4(0.4, 0.7, 0.9, 0.85),
+                    deflection: 0.05
+                )
+                if let body { bodies.append(body) }
+                descriptions.append("LocalRevol: rect profile 270°")
+            }
+
+            // Revolution with angular offset
+            if let profile2 = face.translated(by: SIMD3(3, 0, 0)),
+               let revolvedOffset = profile2.localRevolution(
+                axisOrigin: SIMD3(0, 0, 0),
+                axisDirection: SIMD3(0, 1, 0),
+                angle: .pi,
+                angularOffset: .pi / 4 // Start 45° offset
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    revolvedOffset, id: "local-revol-offset",
+                    color: SIMD4(0.9, 0.5, 0.3, 0.85), deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 12, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("LocalRevol: 180° with 45° offset")
+            }
+        }
+
+        // --- Draft prism: tapered extrusion from a face ---
+        if let circWire = Wire.circle(radius: 2),
+           let circShape = Shape.face(from: circWire),
+           let circFace = circShape.faces().first {
+            // Two-height draft prism
+            if let draft = circFace.draftPrism(height1: 5, height2: 3, angle: .pi / 12) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    draft, id: "draft-prism-2h", color: SIMD4(0.3, 0.8, 0.5, 0.85),
+                    deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 0, dy: 12, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("DraftPrism: 2-height tapered")
+            }
+
+            // Single-height draft prism
+            if let draft2 = circFace.draftPrism(height: 6, angle: .pi / 8) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    draft2, id: "draft-prism-1h", color: SIMD4(0.8, 0.4, 0.7, 0.85),
+                    deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 12, dy: 12, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("DraftPrism: single-height tapered")
+            }
+        }
+
+        // --- Constrained fill: BSpline surface from boundary edges ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6) {
+            let edges = box.edges()
+            if edges.count >= 4 {
+                // Use first 4 edges of a box for a 4-sided constrained fill
+                if let filled = Shape.constrainedFill(
+                    edge1: edges[0], edge2: edges[1],
+                    edge3: edges[2], edge4: edges[3]
+                ) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        filled, id: "constrained-fill-4",
+                        color: SIMD4(0.9, 0.7, 0.2, 0.85), deflection: 0.05
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 0, dy: 24, dz: 0)
+                        bodies.append(body)
+                    }
+                    if let info = filled.constrainedFillInfo {
+                        descriptions.append("ConstrainedFill: deg \(info.uDegree)×\(info.vDegree) poles \(info.uPoles)×\(info.vPoles)")
+                    } else {
+                        descriptions.append("ConstrainedFill: 4-edge surface")
+                    }
+                }
+
+                // 3-sided fill
+                if let filled3 = Shape.constrainedFill(
+                    edge1: edges[0], edge2: edges[1], edge3: edges[2]
+                ) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        filled3, id: "constrained-fill-3",
+                        color: SIMD4(0.5, 0.9, 0.7, 0.85), deflection: 0.05
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 12, dy: 24, dz: 0)
+                        bodies.append(body)
+                    }
+                    descriptions.append("ConstrainedFill: 3-edge surface")
+                }
+            }
+        }
+
+        // --- BRepCheck: validate shapes ---
+        if let box = Shape.box(width: 4, height: 4, depth: 4) {
+            let check = box.checkResult
+            let statuses = box.detailedCheckStatuses
+            descriptions.append("BRepCheck box: valid=\(check.isValid) errors=\(check.errorCount) statuses=\(statuses.count)")
+
+            // Check individual faces
+            let faces = box.faces()
+            if let firstFace = faces.first {
+                let faceCheck = firstFace.faceCheckResult
+                descriptions.append("Face check: valid=\(faceCheck.isValid)")
+            }
+        }
+
+        // Deliberately check an empty/degenerate scenario
+        if let sphere = Shape.sphere(radius: 3) {
+            let check = sphere.checkResult
+            descriptions.append("BRepCheck sphere: valid=\(check.isValid) errors=\(check.errorCount)")
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: descriptions.joined(separator: "\n")
+        )
+    }
+
+    // MARK: - v0.48: Split Ops, Line Intersection & Extrema
+
+    /// Split operations, line-shape intersection, distance extrema, and shape upgrade.
+    static func splitOpsAndExtrema() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- Local pipe: sweep circle along a helix spine ---
+        if let circWire = Wire.circle(radius: 0.5),
+           let circFace = Shape.face(from: circWire),
+           let spine = Wire.helix(radius: 3, pitch: 2.0, turns: 3) {
+            if let pipe = circFace.localPipe(along: spine) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    pipe, id: "local-pipe", color: SIMD4(0.4, 0.7, 0.9, 0.85),
+                    deflection: 0.1
+                )
+                if let body { bodies.append(body) }
+                descriptions.append("LocalPipe: circle swept along helix")
+            }
+        }
+
+        // --- Local linear form: translation sweep ---
+        if let rectWire = Wire.rectangle(width: 2, height: 1),
+           let face = Shape.face(from: rectWire) {
+            if let linear = face.localLinearForm(
+                direction: SIMD3(1, 0, 1),
+                from: SIMD3(0, 0, 0),
+                to: SIMD3(5, 0, 5)
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    linear, id: "linear-form", color: SIMD4(0.9, 0.6, 0.3, 0.85),
+                    deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("LinearForm: rect swept along diagonal")
+            }
+        }
+
+        // --- Split edge: split a box edge at midpoint ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6) {
+            let edgesBefore = box.edges().count
+            if let split = box.splitEdge(at: 0, parameter: 0.5) {
+                let edgesAfter = split.edges().count
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    split, id: "split-edge", color: SIMD4(0.5, 0.8, 0.4, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 0, dy: 14, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("SplitEdge: \(edgesBefore)→\(edgesAfter) edges")
+            }
+        }
+
+        // --- Intersect line: shoot a line through a sphere and find hit points ---
+        if let sphere = Shape.sphere(radius: 3) {
+            let hits = sphere.intersectLine(
+                origin: SIMD3(-10, 0, 0),
+                direction: SIMD3(1, 0, 0)
+            )
+            // Show sphere
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sphere, id: "intersect-sphere", color: SIMD4(0.6, 0.6, 0.9, 0.4),
+                deflection: 0.05
+            )
+            if var body {
+                offsetBody(&body, dx: 14, dy: 14, dz: 0)
+                bodies.append(body)
+            }
+            // Show hit points as markers
+            for (i, hit) in hits.enumerated() {
+                let p = SIMD3<Float>(Float(hit.point.x) + 14, Float(hit.point.y) + 14, Float(hit.point.z))
+                bodies.append(makeMarker(at: p, radius: 0.4, id: "hit-\(i)",
+                                         color: SIMD4(1, 0.2, 0.2, 1)))
+            }
+            // Show the line itself
+            let lineStart = SIMD3<Float>(-10 + 14, 0 + 14, 0)
+            let lineEnd = SIMD3<Float>(10 + 14, 0 + 14, 0)
+            bodies.append(ViewportBody(
+                id: "intersect-line", vertexData: [], indices: [],
+                edges: [[lineStart, lineEnd]], color: SIMD4(1, 0.4, 0.4, 1)
+            ))
+            descriptions.append("IntersectLine: \(hits.count) hits on sphere")
+        }
+
+        // --- Edge-edge extrema: distance between edges of two shapes ---
+        if let box1 = Shape.box(width: 4, height: 4, depth: 4),
+           let box2orig = Shape.box(width: 3, height: 3, depth: 3),
+           let box2 = box2orig.translated(by: SIMD3(8, 0, 0)) {
+            if let extrema = box1.edgeEdgeExtrema(edgeIndex1: 0, other: box2, edgeIndex2: 0) {
+                let p1 = SIMD3<Float>(Float(extrema.pointOnEdge1.x), Float(extrema.pointOnEdge1.y), Float(extrema.pointOnEdge1.z))
+                let p2 = SIMD3<Float>(Float(extrema.pointOnEdge2.x), Float(extrema.pointOnEdge2.y), Float(extrema.pointOnEdge2.z))
+
+                // Show both boxes
+                let (b1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box1, id: "ee-box1", color: SIMD4(0.7, 0.7, 0.7, 0.5), deflection: 0.02
+                )
+                let (b2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box2, id: "ee-box2", color: SIMD4(0.7, 0.7, 0.7, 0.5), deflection: 0.02
+                )
+                if var b1 { offsetBody(&b1, dx: 0, dy: 28, dz: 0); bodies.append(b1) }
+                if var b2 { offsetBody(&b2, dx: 0, dy: 28, dz: 0); bodies.append(b2) }
+
+                // Draw distance line
+                let offset = SIMD3<Float>(0, 28, 0)
+                bodies.append(ViewportBody(
+                    id: "ee-dist-line", vertexData: [], indices: [],
+                    edges: [[p1 + offset, p2 + offset]], color: SIMD4(1, 0.8, 0.2, 1)
+                ))
+                bodies.append(makeMarker(at: p1 + offset, radius: 0.3, id: "ee-p1", color: SIMD4(1, 0.3, 0.3, 1)))
+                bodies.append(makeMarker(at: p2 + offset, radius: 0.3, id: "ee-p2", color: SIMD4(0.3, 1, 0.3, 1)))
+                descriptions.append("EdgeEdgeExtrema: dist=\(String(format: "%.2f", extrema.distance)) parallel=\(extrema.isParallel)")
+            }
+        }
+
+        // --- Point-face extrema: closest point on a face to an external point ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6) {
+            let testPoint = SIMD3<Double>(3, 10, 3)
+            if let pf = box.pointFaceExtrema(point: testPoint, faceIndex: 0) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box, id: "pf-box", color: SIMD4(0.6, 0.6, 0.6, 0.5), deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 28, dz: 0)
+                    bodies.append(body)
+                }
+                let offset = SIMD3<Float>(14, 28, 0)
+                let tp = SIMD3<Float>(Float(testPoint.x), Float(testPoint.y), Float(testPoint.z)) + offset
+                let fp = SIMD3<Float>(Float(pf.pointOnFace.x), Float(pf.pointOnFace.y), Float(pf.pointOnFace.z)) + offset
+                bodies.append(makeMarker(at: tp, radius: 0.4, id: "pf-test", color: SIMD4(1, 0.3, 0.3, 1)))
+                bodies.append(makeMarker(at: fp, radius: 0.4, id: "pf-face", color: SIMD4(0.3, 1, 0.3, 1)))
+                bodies.append(ViewportBody(
+                    id: "pf-line", vertexData: [], indices: [],
+                    edges: [[tp, fp]], color: SIMD4(1, 0.8, 0.2, 1)
+                ))
+                descriptions.append("PointFaceExtrema: dist=\(String(format: "%.2f", pf.distance))")
+            }
+        }
+
+        // --- Divided closed faces: split cylinder's closed face ---
+        if let cyl = Shape.cylinder(radius: 3, height: 8) {
+            let facesBefore = cyl.faces().count
+            if let divided = cyl.dividedClosedFaces() {
+                let facesAfter = divided.faces().count
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    divided, id: "divided-closed", color: SIMD4(0.7, 0.5, 0.9, 0.85),
+                    deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 28, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("DividedClosed: cyl faces \(facesBefore)→\(facesAfter)")
+            }
+        }
+
+        // --- Divided by continuity: split at C1 breaks ---
+        if let box = Shape.box(width: 4, height: 4, depth: 4),
+           let filleted = box.filleted(radius: 0.8) {
+            let edgesBefore = filleted.edges().count
+            if let divided = filleted.dividedByContinuity(criterion: .c2) {
+                let edgesAfter = divided.edges().count
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    divided, id: "divided-cont", color: SIMD4(0.5, 0.8, 0.6, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 28, dy: 14, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("DividedByContinuity(C2): edges \(edgesBefore)→\(edgesAfter)")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: descriptions.joined(separator: "\n")
+        )
+    }
+
     private static func polylineToBody(
         _ points: [SIMD3<Float>],
         id: String,

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -264,12 +264,14 @@ enum OCCT8Gallery {
 
     // MARK: - v0.29: Shape Operations
 
-    /// Demonstrates NURBS conversion, fast sewing, and draft extrusion.
+    /// Demonstrates NURBS conversion and fast sewing.
     static func shapeOperations() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
 
         // Original cylinder
         if let cyl = Shape.cylinder(radius: 1.5, height: 4.0) {
+            let origContents = cyl.contents
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                 cyl, id: "op-original", color: SIMD4(0.6, 0.6, 0.6, 0.5)
             )
@@ -277,6 +279,7 @@ enum OCCT8Gallery {
 
             // NURBS-converted version — offset right
             if let nurbs = cyl.convertedToNURBS() {
+                let nurbsContents = nurbs.contents
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                     nurbs, id: "op-nurbs", color: SIMD4(0.3, 0.7, 1.0, 1.0)
                 )
@@ -284,36 +287,38 @@ enum OCCT8Gallery {
                     offsetBody(&body, dx: 5, dy: 0, dz: 0)
                     bodies.append(body)
                 }
+                descriptions.append("NURBS: \(origContents.faces)F→\(nurbsContents.faces)F")
             }
         }
 
-        // Box + fast sewing demo: create faces and sew them
+        // Fast sewing: explode a box into loose shells, then sew back together
         if let box = Shape.box(width: 3, height: 2, depth: 2) {
+            let origContents = box.contents
+            // Show the original box
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "op-presew", color: SIMD4(0.6, 0.6, 0.6, 0.5)
+            )
+            if var orig {
+                offsetBody(&orig, dx: -5, dy: 0, dz: 0)
+                bodies.append(orig)
+            }
+
             if let sewn = box.fastSewn() {
+                let sewnContents = sewn.contents
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                     sewn, id: "op-fastsewn", color: SIMD4(0.9, 0.6, 0.3, 1.0)
                 )
                 if var body {
-                    offsetBody(&body, dx: -5, dy: 0, dz: 0)
+                    offsetBody(&body, dx: -5, dy: 5, dz: 0)
                     bodies.append(body)
                 }
-            }
-        }
-
-        // Wedge for variety — offset back
-        if let wedge = Shape.wedge(dx: 3, dy: 2, dz: 3, ltx: 0.5) {
-            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                wedge, id: "op-wedge", color: SIMD4(0.5, 0.9, 0.5, 1.0)
-            )
-            if var body {
-                offsetBody(&body, dx: 0, dy: 5, dz: 0)
-                bodies.append(body)
+                descriptions.append("Sew: \(origContents.shells)sh→\(sewnContents.shells)sh")
             }
         }
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "Shape ops: original, NURBS conversion, fast sewing, wedge"
+            description: "v0.29 Shape ops: " + descriptions.joined(separator: " | ")
         )
     }
 
@@ -671,6 +676,7 @@ enum OCCT8Gallery {
     /// Demonstrates makeVolume from faces and makeConnected.
     static func volumeOps() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
 
         // Make a volume from overlapping boxes
         if let box1 = Shape.box(width: 3, height: 3, depth: 3),
@@ -695,10 +701,8 @@ enum OCCT8Gallery {
                     offsetBody(&body, dx: 8, dy: 0, dz: 0)
                     bodies.append(body)
                 }
-
                 let c = volume.contents
-                bodies.append(contentsOf: []) // no-op; just use c below
-                _ = c // description will reference it
+                descriptions.append("makeVolume: \(c.solids)S \(c.faces)F")
             }
         }
 
@@ -729,12 +733,14 @@ enum OCCT8Gallery {
                     offsetBody(&body, dx: 8, dy: 8, dz: 0)
                     bodies.append(body)
                 }
+                let c = connected.contents
+                descriptions.append("makeConnected: \(c.solids)S \(c.faces)F")
             }
         }
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.30: makeVolume (green) from overlapping boxes, makeConnected (yellow)"
+            description: "v0.30: " + descriptions.joined(separator: " | ")
         )
     }
 
@@ -1398,6 +1404,7 @@ enum OCCT8Gallery {
     /// Demonstrates split-by-angle and drop-small-edges repair operations.
     static func shapeRepair() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
 
         // Full cylinder — surfaces span 360°
         if let cyl = Shape.cylinder(radius: 2, height: 4) {
@@ -1421,12 +1428,13 @@ enum OCCT8Gallery {
                 }
 
                 let splitContents = split.contents
-                _ = (origContents, splitContents) // used in description
+                descriptions.append("Cyl split90: \(origContents.faces)F→\(splitContents.faces)F")
             }
         }
 
         // Sphere — split by 90° creates octant patches
         if let sph = Shape.sphere(radius: 2) {
+            let origContents = sph.contents
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                 sph, id: "repair-sph", color: SIMD4(0.6, 0.6, 0.6, 0.5),
                 deflection: 0.02
@@ -1445,6 +1453,8 @@ enum OCCT8Gallery {
                     offsetBody(&body, dx: 7, dy: 7, dz: 0)
                     bodies.append(body)
                 }
+                let splitContents = split.contents
+                descriptions.append("Sph split90: \(origContents.faces)F→\(splitContents.faces)F")
             }
         }
 
@@ -1452,6 +1462,7 @@ enum OCCT8Gallery {
         if let box = Shape.box(width: 4, height: 4, depth: 4) {
             // Fillet with a very small radius to create tiny edges
             if let filleted = box.filleted(radius: 0.01) {
+                let filletedContents = filleted.contents
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                     filleted, id: "repair-tiny", color: SIMD4(0.6, 0.6, 0.6, 0.5)
                 )
@@ -1461,6 +1472,7 @@ enum OCCT8Gallery {
                 }
 
                 if let cleaned = filleted.droppingSmallEdges(tolerance: 0.05) {
+                    let cleanedContents = cleaned.contents
                     let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                         cleaned, id: "repair-cleaned", color: SIMD4(0.3, 0.9, 0.4, 0.9)
                     )
@@ -1468,13 +1480,14 @@ enum OCCT8Gallery {
                         offsetBody(&body, dx: 7, dy: 14, dz: 0)
                         bodies.append(body)
                     }
+                    descriptions.append("DropSmall: \(filletedContents.edges)E→\(cleanedContents.edges)E")
                 }
             }
         }
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.34 Repair: splitByAngle 90° (blue/orange), dropSmallEdges (green)"
+            description: "v0.34 Repair: " + descriptions.joined(separator: " | ")
         )
     }
 
@@ -1483,21 +1496,22 @@ enum OCCT8Gallery {
     /// Demonstrates fuseAll vs sequential union for multiple shapes.
     static func multiFuse() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
 
         // Create 4 overlapping cylinders in a cross pattern
-        let shapes: [(Shape, SIMD3<Double>)] = {
-            var result: [(Shape, SIMD3<Double>)] = []
+        let shapes: [Shape] = {
+            var result: [Shape] = []
             if let c1 = Shape.cylinder(radius: 1, height: 6) {
-                result.append((c1, .zero))
+                result.append(c1)
             }
             if let c2 = Shape.cylinder(radius: 1, height: 6)?.rotated(axis: SIMD3(1, 0, 0), angle: .pi / 2) {
-                result.append((c2, .zero))
+                result.append(c2)
             }
             if let c3 = Shape.cylinder(radius: 1, height: 6)?.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2) {
-                result.append((c3, .zero))
+                result.append(c3)
             }
             if let c4 = Shape.cylinder(radius: 0.8, height: 6)?.rotated(axis: SIMD3(1, 1, 0), angle: .pi / 4) {
-                result.append((c4, .zero))
+                result.append(c4)
             }
             return result
         }()
@@ -1507,7 +1521,7 @@ enum OCCT8Gallery {
             SIMD4(0.3, 0.6, 1.0, 0.2), SIMD4(0.9, 0.5, 0.3, 0.2),
             SIMD4(0.3, 0.9, 0.4, 0.2), SIMD4(0.8, 0.4, 0.8, 0.2)
         ]
-        for (i, (shape, _)) in shapes.enumerated() {
+        for (i, shape) in shapes.enumerated() {
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                 shape, id: "fuse-orig-\(i)", color: colors[i],
                 deflection: 0.02
@@ -1516,8 +1530,7 @@ enum OCCT8Gallery {
         }
 
         // fuseAll — simultaneous multi-tool boolean
-        let allShapes = shapes.map { $0.0 }
-        if let fused = Shape.fuseAll(allShapes) {
+        if let fused = Shape.fuseAll(shapes) {
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                 fused, id: "fuse-all", color: SIMD4(0.3, 0.7, 1.0, 0.9),
                 deflection: 0.02
@@ -1526,14 +1539,13 @@ enum OCCT8Gallery {
                 offsetBody(&body, dx: 10, dy: 0, dz: 0)
                 bodies.append(body)
             }
-
             let c = fused.contents
-            _ = c
+            descriptions.append("fuseAll: \(c.faces)F \(c.edges)E")
         }
 
         // Sequential union for comparison
-        var seqResult: Shape? = allShapes.first
-        for shape in allShapes.dropFirst() {
+        var seqResult: Shape? = shapes.first
+        for shape in shapes.dropFirst() {
             seqResult = seqResult?.union(with: shape)
         }
         if let seq = seqResult {
@@ -1545,11 +1557,13 @@ enum OCCT8Gallery {
                 offsetBody(&body, dx: 20, dy: 0, dz: 0)
                 bodies.append(body)
             }
+            let c = seq.contents
+            descriptions.append("sequential: \(c.faces)F \(c.edges)E")
         }
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.34 Multi-fuse: originals (left), fuseAll (blue), sequential union (orange)"
+            description: "v0.34 Multi-fuse: " + descriptions.joined(separator: " vs ")
         )
     }
 
@@ -1558,6 +1572,7 @@ enum OCCT8Gallery {
     /// Demonstrates imprinting a wire onto a face to split it.
     static func splitFaceByWire() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var desc = "v0.34 Split face: original (gray)"
 
         // Box with a wire imprinted on a face
         if let box = Shape.box(width: 6, height: 4, depth: 4) {
@@ -1571,7 +1586,7 @@ enum OCCT8Gallery {
 
             // Create a wire on the top face (Y=2) — a diagonal line
             if let wire = Wire.line(from: SIMD3(-2, 2, -1), to: SIMD3(2, 2, 1)) {
-                // Top face index varies by OCCT internals; try face 2 (commonly the top)
+                // Top face index varies by OCCT internals; try all faces
                 for faceIdx in 0..<origContents.faces {
                     if let split = box.splittingFace(with: wire, faceIndex: faceIdx) {
                         let splitContents = split.contents
@@ -1584,6 +1599,7 @@ enum OCCT8Gallery {
                                 offsetBody(&body, dx: 10, dy: 0, dz: 0)
                                 bodies.append(body)
                             }
+                            desc += ", split face \(faceIdx): \(origContents.faces)F→\(splitContents.faces)F (blue)"
                             break
                         }
                     }
@@ -1593,7 +1609,7 @@ enum OCCT8Gallery {
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.34 Split face: original (gray), face split by wire imprint (blue)"
+            description: desc
         )
     }
 
@@ -1663,9 +1679,11 @@ enum OCCT8Gallery {
     /// Demonstrates face subdivision and conical (point-source) projection.
     static func faceDivision() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
 
         // Face division: split cylinder faces into patches
         if let cyl = Shape.cylinder(radius: 2, height: 4) {
+            let origC = cyl.contents
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
                 cyl, id: "div-orig", color: SIMD4(0.6, 0.6, 0.6, 0.5),
                 deflection: 0.02
@@ -1683,9 +1701,8 @@ enum OCCT8Gallery {
                     bodies.append(body)
                 }
 
-                let origC = cyl.contents
                 let divC = divided.contents
-                _ = (origC, divC)
+                descriptions.append("Divide: \(origC.faces)F→\(divC.faces)F")
             }
         }
 
@@ -1724,7 +1741,7 @@ enum OCCT8Gallery {
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.36: Face division (blue, more patches), conical projection from eye (right)"
+            description: "v0.36: " + descriptions.joined(separator: " | ") + ". Conical projection (right)."
         )
     }
 
@@ -1953,6 +1970,298 @@ enum OCCT8Gallery {
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
             description: "Left: original. Center: uniform offset. Right: per-face variable offset (some faces thicker)."
+        )
+    }
+
+    // MARK: - v0.39: Free Bounds, Pipe Feature, Semi-Infinite Extrusion
+
+    /// Demonstrates free boundary analysis, pipe feature, and semi-infinite extrusion.
+    static func freeBoundsAndFeatures() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // Free bounds: open shell (box missing one face) should show free edges
+        if let box = Shape.box(width: 4, height: 4, depth: 4) {
+            // Show the original solid box
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "fb-solid", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let orig { bodies.append(orig) }
+
+            // Analyze free bounds on the solid (should have none)
+            if let fb = box.freeBounds() {
+                descriptions.append("Solid: \(fb.closedCount) closed, \(fb.openCount) open free bounds")
+            } else {
+                descriptions.append("Solid: no free bounds (watertight)")
+            }
+
+            // Hollow the box to create an open shell, then check free bounds
+            for faceIdx in 0..<box.contents.faces {
+                if let hollowed = box.hollowed(removingFaces: [faceIdx], thickness: 0.3) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        hollowed, id: "fb-open", color: SIMD4(0.3, 0.7, 1.0, 0.8)
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 8, dy: 0, dz: 0)
+                        bodies.append(body)
+                    }
+
+                    if let fb = hollowed.freeBounds() {
+                        descriptions.append("Hollow: \(fb.closedCount) closed, \(fb.openCount) open")
+                        // Show the free boundary wires
+                        let (wireBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                            fb.wires, id: "fb-wires", color: SIMD4(1.0, 0.2, 0.2, 1.0),
+                            deflection: 0.02
+                        )
+                        if var wireBody {
+                            offsetBody(&wireBody, dx: 8, dy: 0, dz: 0)
+                            bodies.append(wireBody)
+                        }
+                    }
+                    break
+                }
+            }
+        }
+
+        // Semi-infinite extrusion
+        if let circle = Wire.circle(radius: 1),
+           let face = Shape.face(from: circle) {
+            if let semiInf = face.extrudedSemiInfinite(direction: SIMD3(0, 0, 1)) {
+                // The semi-infinite shape is huge; section it with a box for display
+                if let clipBox = Shape.box(width: 6, height: 6, depth: 8),
+                   let clipped = clipBox.intersection(with: semiInf) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        clipped, id: "fb-semiinf", color: SIMD4(0.9, 0.5, 0.3, 0.8),
+                        deflection: 0.02
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 16, dy: 0, dz: 0)
+                        bodies.append(body)
+                    }
+                    descriptions.append("Semi-inf extrusion (clipped)")
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.39: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.40: Inertia Properties & Extended Distance
+
+    /// Demonstrates volume/surface inertia and multi-solution distance queries.
+    static func inertiaAndDistance() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // Inertia properties: box vs cylinder — compare center of mass and principal axes
+        if let box = Shape.box(width: 6, height: 2, depth: 3) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "inertia-box", color: SIMD4(0.3, 0.6, 1.0, 0.8)
+            )
+            if let body { bodies.append(body) }
+
+            if let props = box.inertiaProperties() {
+                let com = props.centerOfMass
+                bodies.append(makeMarker(
+                    at: SIMD3<Float>(Float(com.x), Float(com.y), Float(com.z)),
+                    radius: 0.2, id: "inertia-box-com",
+                    color: SIMD4(1.0, 0.2, 0.2, 1.0)
+                ))
+
+                // Show principal axes as lines from center of mass
+                let axisLen: Double = 2.0
+                let axisColors: [SIMD4<Float>] = [
+                    SIMD4(1, 0, 0, 1), SIMD4(0, 1, 0, 1), SIMD4(0, 0, 1, 1)
+                ]
+                let axes = [props.principalAxes.0, props.principalAxes.1, props.principalAxes.2]
+                for (i, axis) in axes.enumerated() {
+                    let start = SIMD3<Float>(Float(com.x), Float(com.y), Float(com.z))
+                    let end = SIMD3<Float>(
+                        Float(com.x + axis.x * axisLen),
+                        Float(com.y + axis.y * axisLen),
+                        Float(com.z + axis.z * axisLen)
+                    )
+                    bodies.append(ViewportBody(id: "inertia-box-axis-\(i)", vertexData: [], indices: [],
+                                               edges: [[start, end]], color: axisColors[i]))
+                }
+                descriptions.append("Box: vol=\(String(format: "%.1f", props.mass))")
+            }
+        }
+
+        if let cyl = Shape.cylinder(radius: 1.5, height: 4) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "inertia-cyl", color: SIMD4(0.3, 0.9, 0.4, 0.8),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            if let props = cyl.inertiaProperties() {
+                let com = props.centerOfMass
+                var marker = makeMarker(
+                    at: SIMD3<Float>(Float(com.x), Float(com.y), Float(com.z)),
+                    radius: 0.2, id: "inertia-cyl-com",
+                    color: SIMD4(1.0, 0.2, 0.2, 1.0)
+                )
+                offsetBody(&marker, dx: 10, dy: 0, dz: 0)
+                bodies.append(marker)
+                descriptions.append("Cyl: vol=\(String(format: "%.1f", props.mass))")
+            }
+        }
+
+        // Extended distance: all closest point pairs between two shapes
+        if let box = Shape.box(width: 2, height: 2, depth: 2),
+           let sph = Shape.sphere(radius: 1)?.translated(by: SIMD3(4, 0, 0)) {
+
+            let (b1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "dist-box", color: SIMD4(0.5, 0.7, 0.9, 0.6)
+            )
+            if var b1 {
+                offsetBody(&b1, dx: 0, dy: 8, dz: 0)
+                bodies.append(b1)
+            }
+            let (b2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sph, id: "dist-sph", color: SIMD4(0.9, 0.6, 0.4, 0.6),
+                deflection: 0.02
+            )
+            if var b2 {
+                offsetBody(&b2, dx: 0, dy: 8, dz: 0)
+                bodies.append(b2)
+            }
+
+            if let solutions = box.allDistanceSolutions(to: sph, maxSolutions: 8) {
+                for (i, sol) in solutions.enumerated() {
+                    let p1 = SIMD3<Float>(Float(sol.point1.x), Float(sol.point1.y) + 8, Float(sol.point1.z))
+                    let p2 = SIMD3<Float>(Float(sol.point2.x), Float(sol.point2.y) + 8, Float(sol.point2.z))
+                    bodies.append(makeMarker(at: p1, radius: 0.1, id: "dist-p1-\(i)",
+                                             color: SIMD4(1.0, 0.2, 0.2, 1.0)))
+                    bodies.append(makeMarker(at: p2, radius: 0.1, id: "dist-p2-\(i)",
+                                             color: SIMD4(0.2, 1.0, 0.2, 1.0)))
+                    bodies.append(ViewportBody(id: "dist-line-\(i)", vertexData: [], indices: [],
+                                               edges: [[p1, p2]], color: SIMD4(1.0, 1.0, 0.0, 1.0)))
+                }
+                descriptions.append("\(solutions.count) distance solutions")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.40: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.41: Shape Surgery & Plane Detection
+
+    /// Demonstrates plane detection, geometry conversion, closed edge splitting,
+    /// and face restriction.
+    static func surgeryAndDetection() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // Face restriction: cut a face using a wire boundary
+        if let cyl = Shape.cylinder(radius: 2, height: 5) {
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "restrict-orig", color: SIMD4(0.6, 0.6, 0.6, 0.4),
+                deflection: 0.02
+            )
+            if let orig { bodies.append(orig) }
+
+            // Create a restricting wire (a circle on the XY plane)
+            if let clipWire = Wire.circle(radius: 1.5) {
+                if let restricted = cyl.faceRestricted(by: [clipWire]) {
+                    for (i, face) in restricted.enumerated() {
+                        let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                            face, id: "restrict-\(i)", color: SIMD4(0.3, 0.7, 1.0, 0.9),
+                            deflection: 0.02
+                        )
+                        if var body {
+                            offsetBody(&body, dx: 6, dy: 0, dz: 0)
+                            bodies.append(body)
+                        }
+                    }
+                    descriptions.append("Face restrict: \(restricted.count) result faces")
+                }
+            }
+        }
+
+        // Plane detection: check if various wires are planar
+        if let flatWire = Wire.path([
+            SIMD3(0, 0, 0), SIMD3(3, 0, 0), SIMD3(3, 3, 0), SIMD3(0, 3, 0)
+        ], closed: true),
+           let flatShape = Shape.fromWire(flatWire) {
+
+            // Show the wire
+            var flatBody = wireToBody(flatWire, id: "plane-flat",
+                                      color: SIMD4(0.3, 0.9, 0.4, 1.0))
+            offsetBody(&flatBody, dx: 14, dy: 0, dz: 0)
+            bodies.append(flatBody)
+
+            if let plane = flatShape.findPlane() {
+                let n = plane.normal
+                let o = plane.origin
+                descriptions.append("Planar: n=(\(String(format: "%.0f,%.0f,%.0f", n.x, n.y, n.z)))")
+
+                // Show the detected plane normal as a line from the wire's center
+                let start = SIMD3<Float>(Float(o.x) + 14, Float(o.y), Float(o.z))
+                let end = SIMD3<Float>(Float(o.x + n.x * 2) + 14, Float(o.y + n.y * 2), Float(o.z + n.z * 2))
+                bodies.append(ViewportBody(id: "plane-normal", vertexData: [], indices: [],
+                                           edges: [[start, end]], color: SIMD4(1.0, 0.3, 0.3, 1.0)))
+            }
+        }
+
+        // Geometry conversion: cylinder surfaces to BSpline and to Revolution
+        if let cyl = Shape.cylinder(radius: 2, height: 4) {
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "conv-orig", color: SIMD4(0.6, 0.6, 0.6, 0.5),
+                deflection: 0.02
+            )
+            if var orig {
+                offsetBody(&orig, dx: 0, dy: 10, dz: 0)
+                bodies.append(orig)
+            }
+
+            if let bspline = cyl.withSurfacesAsBSpline() {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    bspline, id: "conv-bspline", color: SIMD4(0.9, 0.5, 0.3, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 6, dy: 10, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("Surfaces→BSpline")
+            }
+
+            if let rev = cyl.withSurfacesAsRevolution() {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    rev, id: "conv-revolution", color: SIMD4(0.3, 0.9, 0.7, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 12, dy: 10, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("Surfaces→Revolution")
+            }
+        }
+
+        // Closed edge splitting
+        if let cyl = Shape.cylinder(radius: 1.5, height: 3) {
+            let origContents = cyl.contents
+            if let split = cyl.dividedClosedEdges() {
+                let splitContents = split.contents
+                descriptions.append("Split closed edges: \(origContents.edges)E→\(splitContents.edges)E")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.41: " + descriptions.joined(separator: " | ")
         )
     }
 

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -831,7 +831,8 @@ enum OCCT8Gallery {
         if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .stretch),
            let shell = Shape.shell(from: surf) {
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                shell, id: "bf-stretch", color: SIMD4(0.3, 0.6, 1.0, 0.8)
+                shell, id: "bf-stretch", color: SIMD4(0.3, 0.6, 1.0, 0.8),
+                deflection: 0.01
             )
             if let body { bodies.append(body) }
         }
@@ -840,7 +841,8 @@ enum OCCT8Gallery {
         if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .coons),
            let shell = Shape.shell(from: surf) {
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                shell, id: "bf-coons", color: SIMD4(0.3, 0.9, 0.4, 0.8)
+                shell, id: "bf-coons", color: SIMD4(0.3, 0.9, 0.4, 0.8),
+                deflection: 0.01
             )
             if var body {
                 offsetBody(&body, dx: 10, dy: 0, dz: 0)
@@ -852,7 +854,8 @@ enum OCCT8Gallery {
         if let surf = Surface.bezierFill(c1, c2, c3, c4, style: .curved),
            let shell = Shape.shell(from: surf) {
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                shell, id: "bf-curved", color: SIMD4(0.9, 0.5, 0.3, 0.8)
+                shell, id: "bf-curved", color: SIMD4(0.9, 0.5, 0.3, 0.8),
+                deflection: 0.01
             )
             if var body {
                 offsetBody(&body, dx: 20, dy: 0, dz: 0)
@@ -879,7 +882,8 @@ enum OCCT8Gallery {
         ]) {
             if let glass = Shape.revolution(meridian: profile) {
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    glass, id: "rev-glass", color: SIMD4(0.4, 0.7, 1.0, 0.8)
+                    glass, id: "rev-glass", color: SIMD4(0.4, 0.7, 1.0, 0.8),
+                    deflection: 0.01
                 )
                 if let body { bodies.append(body) }
             }
@@ -899,7 +903,8 @@ enum OCCT8Gallery {
         ]) {
             if let vase = Shape.revolution(meridian: profile) {
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    vase, id: "rev-vase", color: SIMD4(0.9, 0.5, 0.3, 0.8)
+                    vase, id: "rev-vase", color: SIMD4(0.9, 0.5, 0.3, 0.8),
+                    deflection: 0.01
                 )
                 if var body {
                     offsetBody(&body, dx: 8, dy: 0, dz: 0)
@@ -908,16 +913,17 @@ enum OCCT8Gallery {
             }
         }
 
-        // Partial revolution (half turn) of a circle arc — creates a dome
-        if let arc = Curve3D.line(through: SIMD3(0, 0, 0), direction: SIMD3(1, 0, 1)) {
+        // Partial revolution (half turn) of a line segment — creates a cone
+        if let seg = Curve3D.segment(from: SIMD3(1, 0, 0), to: SIMD3(2, 0, 4)) {
             if let half = Shape.revolution(
-                meridian: arc,
-                axisOrigin: SIMD3(-6, 0, 0),
+                meridian: seg,
+                axisOrigin: SIMD3(0, 0, 0),
                 axisDirection: SIMD3(0, 0, 1),
                 angle: .pi
             ) {
                 let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                    half, id: "rev-half", color: SIMD4(0.5, 0.9, 0.5, 0.8)
+                    half, id: "rev-half", color: SIMD4(0.5, 0.9, 0.5, 0.8),
+                    deflection: 0.01
                 )
                 if var body {
                     offsetBody(&body, dx: -6, dy: 0, dz: 0)
@@ -937,8 +943,11 @@ enum OCCT8Gallery {
     /// Adds reinforcing ribs to a base shape.
     static func linearRibDemo() -> Curve2DGallery.GalleryResult {
         var bodies: [ViewportBody] = []
+        var ribSuccess = false
 
-        // Base plate
+        // Base plate — box(width:height:depth:) is centered at origin
+        // width=10 → X: -5..5, height=2 → Y: -1..1, depth=8 → Z: -4..4
+        // Top face is at Y=1
         if let plate = Shape.box(width: 10, height: 2, depth: 8) {
             // Show original
             let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
@@ -946,22 +955,245 @@ enum OCCT8Gallery {
             )
             if let body { bodies.append(body) }
 
-            // Add a rib profile along the top face
+            // Rib profile: a line on the top face (Y=1), running along X
+            // direction = extrusion up (Y+), draftDirection = along Z
             if let ribProfile = Wire.line(
-                from: SIMD3(1, 2, 1),
-                to: SIMD3(9, 2, 1)
+                from: SIMD3(-4, 1, 0),
+                to: SIMD3(4, 1, 0)
             ) {
                 if let ribbed = plate.addingLinearRib(
                     profile: ribProfile,
-                    direction: SIMD3(0, 0, 1),
-                    draftDirection: SIMD3(0, 1, 0),
+                    direction: SIMD3(0, 1, 0),
+                    draftDirection: SIMD3(0, 0, 1),
                     fuse: true
                 ) {
                     let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
-                        ribbed, id: "rib-result", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                        ribbed, id: "rib-result", color: SIMD4(0.3, 0.7, 1.0, 1.0),
+                        deflection: 0.02
                     )
                     if var body {
                         offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                        bodies.append(body)
+                        ribSuccess = true
+                    }
+                }
+            }
+
+            // Fallback: if rib failed, simulate by unioning a thin box onto the plate
+            if !ribSuccess {
+                if let rib = Shape.box(width: 8, height: 2, depth: 0.5) {
+                    if let ribMoved = rib.translated(by: SIMD3(0, 2, 0)),
+                       let ribbed = plate.union(with: ribMoved) {
+                        let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                            ribbed, id: "rib-fallback", color: SIMD4(0.3, 0.7, 1.0, 1.0),
+                            deflection: 0.02
+                        )
+                        if var body {
+                            offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                            bodies.append(body)
+                        }
+                    }
+                }
+            }
+        }
+
+        let desc = ribSuccess
+            ? "v0.31 Linear rib: base plate (gray) → with rib (blue)"
+            : "v0.31 Linear rib: base plate (gray) + extruded prism fallback (blue)"
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: desc
+        )
+    }
+
+    // MARK: - v0.32: Asymmetric Chamfer
+
+    /// Demonstrates two-distance and distance-angle chamfer modes.
+    static func asymmetricChamfer() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Base box for chamfering
+        if let box = Shape.box(width: 4, height: 4, depth: 4) {
+            // Original for reference
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "cham-original", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let body { bodies.append(body) }
+
+            // Two-distance chamfer on edge 0 (asymmetric: 0.8 on one side, 0.3 on the other)
+            if let chamfered = box.chamferedTwoDistances([(edgeIndex: 0, faceIndex: 0, dist1: 0.8, dist2: 0.3)]) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    chamfered, id: "cham-twodist", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Distance-angle chamfer on edge 2 (distance=0.5, angle=30°)
+            if let chamfered = box.chamferedDistAngle([(edgeIndex: 2, faceIndex: 0, distance: 0.5, angleDegrees: 30)]) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    chamfered, id: "cham-distangle", color: SIMD4(0.9, 0.5, 0.3, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.32 Chamfers: original (gray), two-distance (blue), dist+angle (orange)"
+        )
+    }
+
+    // MARK: - v0.32: Loft Advanced
+
+    /// Demonstrates ruled loft and vertex-tipped loft (cone).
+    static func loftAdvanced() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Circle at origin in XY, second circle offset to Z=5
+        if let circle1 = Wire.circle(radius: 2.0),
+           let circle2 = Wire.circle(radius: 1.0)?.offset3D(distance: 5, direction: SIMD3(0, 0, 1)) {
+
+            // Ruled loft (straight line segments between profiles)
+            if let ruled = Shape.loft(profiles: [circle1, circle2], solid: true, ruled: true) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    ruled, id: "loft-ruled", color: SIMD4(0.3, 0.7, 1.0, 0.9)
+                )
+                if let body { bodies.append(body) }
+            }
+
+            // Smooth loft (B-spline interpolation)
+            if let smooth = Shape.loft(profiles: [circle1, circle2], solid: true, ruled: false) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    smooth, id: "loft-smooth", color: SIMD4(0.3, 0.9, 0.4, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Vertex-tipped loft (cone: circle to a point)
+            if let cone = Shape.loft(profiles: [circle1], solid: true, ruled: true,
+                                     lastVertex: SIMD3(0, 0, 6)) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    cone, id: "loft-cone", color: SIMD4(0.9, 0.5, 0.3, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.32 Loft: ruled (blue), smooth B-spline (green), vertex-tip cone (orange)"
+        )
+    }
+
+    // MARK: - v0.32: Offset by Join
+
+    /// Demonstrates offset with different join types.
+    static func offsetByJoin() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // L-shaped base: box + box union
+        if let box1 = Shape.box(width: 4, height: 2, depth: 2),
+           let box2 = Shape.box(width: 2, height: 4, depth: 2),
+           let lShape = box1.union(with: box2) {
+
+            // Original
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                lShape, id: "off-original", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let body { bodies.append(body) }
+
+            // Arc join (smooth rounded gaps)
+            if let arc = lShape.offset(by: 0.3, joinType: .arc) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    arc, id: "off-arc", color: SIMD4(0.3, 0.7, 1.0, 0.8)
+                )
+                if var body {
+                    offsetBody(&body, dx: 8, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Intersection join (sharp edges at gaps)
+            if let inter = lShape.offset(by: 0.3, joinType: .intersection) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    inter, id: "off-intersection", color: SIMD4(0.9, 0.5, 0.3, 0.8)
+                )
+                if var body {
+                    offsetBody(&body, dx: 16, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.32 Offset: original (gray), arc join (blue), intersection join (orange)"
+        )
+    }
+
+    // MARK: - v0.32: Draft Prism & Revolved Feature
+
+    /// Demonstrates draft prism (tapered extrusion) and revolved feature on a base shape.
+    static func featureOps() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Base box for features
+        if let box = Shape.box(width: 6, height: 2, depth: 6) {
+            // Show base
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "feat-base", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let body { bodies.append(body) }
+
+            // Draft prism: tapered boss on top face (Y=1)
+            // Profile rectangle on the top face using 3D path
+            if let profile = Wire.path([
+                SIMD3(-1, 1, -1), SIMD3(1, 1, -1),
+                SIMD3(1, 1, 1), SIMD3(-1, 1, 1)
+            ], closed: true) {
+                if let drafted = box.addingDraftPrism(
+                    profile: profile, sketchFaceIndex: 2,
+                    draftAngle: 10, height: 3, fuse: true
+                ) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        drafted, id: "feat-draftprism", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                        bodies.append(body)
+                    }
+                }
+            }
+
+            // Revolved feature: groove cut around Y axis
+            // Profile in XY plane, offset from center
+            if let profile = Wire.path([
+                SIMD3(2.5, 1, -0.25), SIMD3(3.5, 1, -0.25),
+                SIMD3(3.5, 1, 0.25), SIMD3(2.5, 1, 0.25)
+            ], closed: true) {
+                if let revolved = box.addingRevolvedFeature(
+                    profile: profile, sketchFaceIndex: 2,
+                    axisOrigin: SIMD3(0, 0, 0),
+                    axisDirection: SIMD3(0, 1, 0),
+                    angle: 360, fuse: false
+                ) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        revolved, id: "feat-revolved", color: SIMD4(0.9, 0.5, 0.3, 1.0)
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 20, dy: 0, dz: 0)
                         bodies.append(body)
                     }
                 }
@@ -970,7 +1202,398 @@ enum OCCT8Gallery {
 
         return Curve2DGallery.GalleryResult(
             bodies: bodies,
-            description: "v0.31 Linear rib: base plate (gray) → with rib (blue)"
+            description: "v0.32 Features: base (gray), draft prism boss (blue), revolved groove (orange)"
+        )
+    }
+
+    // MARK: - v0.33: Pipe Shell Transitions
+
+    /// Demonstrates pipe shell with different transition modes at spine corners.
+    static func pipeTransitions() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // L-shaped spine with a corner
+        if let spine = Wire.path([
+            SIMD3(0, 0, 0), SIMD3(4, 0, 0), SIMD3(4, 4, 0)
+        ]),
+           let profile = Wire.circle(radius: 0.5) {
+
+            // Transformed (smooth)
+            if let smooth = Shape.pipeShellWithTransition(
+                spine: spine, profile: profile, transition: .transformed
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    smooth, id: "pipe-transformed", color: SIMD4(0.3, 0.7, 1.0, 0.9)
+                )
+                if let body { bodies.append(body) }
+            }
+
+            // Right corner (sharp)
+            if let sharp = Shape.pipeShellWithTransition(
+                spine: spine, profile: profile, transition: .rightCorner
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    sharp, id: "pipe-right", color: SIMD4(0.9, 0.5, 0.3, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 8, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Round corner (filleted)
+            if let round = Shape.pipeShellWithTransition(
+                spine: spine, profile: profile, transition: .roundCorner
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    round, id: "pipe-round", color: SIMD4(0.3, 0.9, 0.4, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 16, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.33 Pipe transitions: smooth (blue), sharp corner (orange), round corner (green)"
+        )
+    }
+
+    // MARK: - v0.33: Face from Surface
+
+    /// Demonstrates creating faces from parametric surfaces and edges-to-faces.
+    static func faceFromSurface() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Face from cylindrical surface with bounded UV
+        if let cylSurf = Surface.cylinder(origin: .zero, axis: SIMD3(0, 0, 1), radius: 2.0) {
+            // Partial cylinder face (half-turn, height 0..4)
+            if let face = cylSurf.toFace(uRange: 0...Double.pi, vRange: 0...4) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    face, id: "face-cyl", color: SIMD4(0.3, 0.7, 1.0, 0.9),
+                    deflection: 0.02
+                )
+                if let body { bodies.append(body) }
+            }
+        }
+
+        // Face from spherical surface with bounded UV
+        if let sphSurf = Surface.sphere(center: SIMD3(0, 0, 0), radius: 2.0) {
+            // Quarter sphere
+            if let face = sphSurf.toFace(
+                uRange: 0...(Double.pi / 2),
+                vRange: 0...(Double.pi / 2)
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    face, id: "face-sph", color: SIMD4(0.3, 0.9, 0.4, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Face from a plane surface
+        if let planeSurf = Surface.plane(origin: .zero, normal: SIMD3(0, 0, 1)) {
+            if let face = planeSurf.toFace(uRange: -3...3, vRange: -2...2) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    face, id: "face-plane", color: SIMD4(0.9, 0.5, 0.3, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.33 Face from surface: half cylinder (blue), quarter sphere (green), bounded plane (orange)"
+        )
+    }
+
+    // MARK: - v0.34: Section Curves & Boolean Validation
+
+    /// Demonstrates shape-to-shape section and boolean pre-validation.
+    static func sectionAndValidation() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // Two intersecting shapes: cylinder through a box
+        if let box = Shape.box(width: 4, height: 4, depth: 4),
+           let cyl = Shape.cylinder(radius: 1.5, height: 6)?.translated(by: SIMD3(0, -3, 0)) {
+
+            // Show both shapes semi-transparent
+            let (b1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "sec-box", color: SIMD4(0.3, 0.6, 1.0, 0.3)
+            )
+            if let b1 { bodies.append(b1) }
+            let (b2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "sec-cyl", color: SIMD4(0.9, 0.5, 0.3, 0.3),
+                deflection: 0.02
+            )
+            if let b2 { bodies.append(b2) }
+
+            // Section: intersection curves
+            if let section = box.section(with: cyl) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    section, id: "sec-curves", color: SIMD4(1.0, 0.2, 0.2, 1.0),
+                    deflection: 0.02
+                )
+                if let body { bodies.append(body) }
+                let c = section.contents
+                descriptions.append("Section: \(c.edges)E")
+            }
+
+            // Boolean pre-validation
+            let boxValid = box.isValidForBoolean
+            let cylValid = cyl.isValidForBoolean
+            let pairValid = box.isValidForBoolean(with: cyl)
+            descriptions.append("Valid: box=\(boxValid), cyl=\(cylValid), pair=\(pairValid)")
+        }
+
+        // Second example: sphere slicing through a box — offset right
+        if let box2 = Shape.box(width: 3, height: 3, depth: 3),
+           let sph = Shape.sphere(radius: 2.5)?.translated(by: SIMD3(1.5, 1.5, 0)) {
+            let (b1, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box2, id: "sec-box2", color: SIMD4(0.3, 0.9, 0.4, 0.3)
+            )
+            if var b1 {
+                offsetBody(&b1, dx: 10, dy: 0, dz: 0)
+                bodies.append(b1)
+            }
+            let (b2, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sph, id: "sec-sph", color: SIMD4(0.8, 0.4, 0.8, 0.3),
+                deflection: 0.02
+            )
+            if var b2 {
+                offsetBody(&b2, dx: 10, dy: 0, dz: 0)
+                bodies.append(b2)
+            }
+
+            if let section = box2.section(with: sph) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    section, id: "sec-curves2", color: SIMD4(1.0, 1.0, 0.0, 1.0),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.34 Section: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.34: Shape Repair (Split by Angle, Drop Small Edges)
+
+    /// Demonstrates split-by-angle and drop-small-edges repair operations.
+    static func shapeRepair() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Full cylinder — surfaces span 360°
+        if let cyl = Shape.cylinder(radius: 2, height: 4) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "repair-cyl", color: SIMD4(0.6, 0.6, 0.6, 0.5),
+                deflection: 0.02
+            )
+            if let body { bodies.append(body) }
+
+            let origContents = cyl.contents
+
+            // Split by angle: 90° — turns full cylinder into quarter-cylinders
+            if let split = cyl.splitByAngle(90) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    split, id: "repair-split90", color: SIMD4(0.3, 0.7, 1.0, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+
+                let splitContents = split.contents
+                _ = (origContents, splitContents) // used in description
+            }
+        }
+
+        // Sphere — split by 90° creates octant patches
+        if let sph = Shape.sphere(radius: 2) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sph, id: "repair-sph", color: SIMD4(0.6, 0.6, 0.6, 0.5),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 7, dz: 0)
+                bodies.append(body)
+            }
+
+            if let split = sph.splitByAngle(90) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    split, id: "repair-sphsplit", color: SIMD4(0.9, 0.5, 0.3, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 7, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Drop small edges demo: create a shape with tiny edges then clean
+        if let box = Shape.box(width: 4, height: 4, depth: 4) {
+            // Fillet with a very small radius to create tiny edges
+            if let filleted = box.filleted(radius: 0.01) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    filleted, id: "repair-tiny", color: SIMD4(0.6, 0.6, 0.6, 0.5)
+                )
+                if var body {
+                    offsetBody(&body, dx: 0, dy: 14, dz: 0)
+                    bodies.append(body)
+                }
+
+                if let cleaned = filleted.droppingSmallEdges(tolerance: 0.05) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        cleaned, id: "repair-cleaned", color: SIMD4(0.3, 0.9, 0.4, 0.9)
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 7, dy: 14, dz: 0)
+                        bodies.append(body)
+                    }
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.34 Repair: splitByAngle 90° (blue/orange), dropSmallEdges (green)"
+        )
+    }
+
+    // MARK: - v0.34: Multi-Fuse
+
+    /// Demonstrates fuseAll vs sequential union for multiple shapes.
+    static func multiFuse() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Create 4 overlapping cylinders in a cross pattern
+        let shapes: [(Shape, SIMD3<Double>)] = {
+            var result: [(Shape, SIMD3<Double>)] = []
+            if let c1 = Shape.cylinder(radius: 1, height: 6) {
+                result.append((c1, .zero))
+            }
+            if let c2 = Shape.cylinder(radius: 1, height: 6)?.rotated(axis: SIMD3(1, 0, 0), angle: .pi / 2) {
+                result.append((c2, .zero))
+            }
+            if let c3 = Shape.cylinder(radius: 1, height: 6)?.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2) {
+                result.append((c3, .zero))
+            }
+            if let c4 = Shape.cylinder(radius: 0.8, height: 6)?.rotated(axis: SIMD3(1, 1, 0), angle: .pi / 4) {
+                result.append((c4, .zero))
+            }
+            return result
+        }()
+
+        // Show individual cylinders semi-transparent
+        let colors: [SIMD4<Float>] = [
+            SIMD4(0.3, 0.6, 1.0, 0.2), SIMD4(0.9, 0.5, 0.3, 0.2),
+            SIMD4(0.3, 0.9, 0.4, 0.2), SIMD4(0.8, 0.4, 0.8, 0.2)
+        ]
+        for (i, (shape, _)) in shapes.enumerated() {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                shape, id: "fuse-orig-\(i)", color: colors[i],
+                deflection: 0.02
+            )
+            if let body { bodies.append(body) }
+        }
+
+        // fuseAll — simultaneous multi-tool boolean
+        let allShapes = shapes.map { $0.0 }
+        if let fused = Shape.fuseAll(allShapes) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                fused, id: "fuse-all", color: SIMD4(0.3, 0.7, 1.0, 0.9),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            let c = fused.contents
+            _ = c
+        }
+
+        // Sequential union for comparison
+        var seqResult: Shape? = allShapes.first
+        for shape in allShapes.dropFirst() {
+            seqResult = seqResult?.union(with: shape)
+        }
+        if let seq = seqResult {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                seq, id: "fuse-seq", color: SIMD4(0.9, 0.5, 0.3, 0.9),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 20, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.34 Multi-fuse: originals (left), fuseAll (blue), sequential union (orange)"
+        )
+    }
+
+    // MARK: - v0.34: Split Face by Wire
+
+    /// Demonstrates imprinting a wire onto a face to split it.
+    static func splitFaceByWire() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Box with a wire imprinted on a face
+        if let box = Shape.box(width: 6, height: 4, depth: 4) {
+            // Show original
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "split-original", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let body { bodies.append(body) }
+
+            let origContents = box.contents
+
+            // Create a wire on the top face (Y=2) — a diagonal line
+            if let wire = Wire.line(from: SIMD3(-2, 2, -1), to: SIMD3(2, 2, 1)) {
+                // Top face index varies by OCCT internals; try face 2 (commonly the top)
+                for faceIdx in 0..<origContents.faces {
+                    if let split = box.splittingFace(with: wire, faceIndex: faceIdx) {
+                        let splitContents = split.contents
+                        // Successfully split if face count increased
+                        if splitContents.faces > origContents.faces {
+                            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                                split, id: "split-result", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                            )
+                            if var body {
+                                offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                                bodies.append(body)
+                            }
+                            break
+                        }
+                    }
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.34 Split face: original (gray), face split by wire imprint (blue)"
         )
     }
 

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -3709,6 +3709,215 @@ enum OCCT8Gallery {
         )
     }
 
+    // MARK: - v0.49: Extrema, Curve Joining, Free Bounds & Analysis
+
+    /// Point-edge/edge-face extrema, curve joining, free bounds analysis,
+    /// surface UV projection, and curve analysis.
+    static func extremaAndCurveAnalysis() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- Point-edge extrema: closest point from external point to box edge ---
+        if let box = Shape.box(width: 8, height: 4, depth: 4) {
+            let testPoint = SIMD3<Double>(6, 5, 2)
+            if let pe = box.pointEdgeExtrema(point: testPoint, edgeIndex: 0) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box, id: "pe-box", color: SIMD4(0.6, 0.6, 0.6, 0.5), deflection: 0.02
+                )
+                if let body { bodies.append(body) }
+                let tp = SIMD3<Float>(Float(testPoint.x), Float(testPoint.y), Float(testPoint.z))
+                let ep = SIMD3<Float>(Float(pe.pointOnEdge.x), Float(pe.pointOnEdge.y), Float(pe.pointOnEdge.z))
+                bodies.append(makeMarker(at: tp, radius: 0.3, id: "pe-test", color: SIMD4(1, 0.3, 0.3, 1)))
+                bodies.append(makeMarker(at: ep, radius: 0.3, id: "pe-edge", color: SIMD4(0.3, 1, 0.3, 1)))
+                bodies.append(ViewportBody(
+                    id: "pe-line", vertexData: [], indices: [],
+                    edges: [[tp, ep]], color: SIMD4(1, 0.8, 0.2, 1)
+                ))
+                descriptions.append("PointEdge: dist=\(String(format: "%.2f", pe.distance)) param=\(String(format: "%.2f", pe.parameter))")
+            }
+        }
+
+        // --- Edge-face extrema: distance from cylinder edge to box face ---
+        if let cyl = Shape.cylinder(radius: 1.5, height: 6),
+           let boxOrig = Shape.box(width: 4, height: 4, depth: 4),
+           let box = boxOrig.translated(by: SIMD3(8, 0, 0)) {
+            if let ef = cyl.edgeFaceExtrema(edgeIndex: 0, other: box, faceIndex: 0) {
+                let (cylBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    cyl, id: "ef-cyl", color: SIMD4(0.5, 0.7, 0.9, 0.7), deflection: 0.05
+                )
+                let (boxBody, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    box, id: "ef-box", color: SIMD4(0.7, 0.7, 0.7, 0.5), deflection: 0.02
+                )
+                if var cylBody { offsetBody(&cylBody, dx: 0, dy: 14, dz: 0); bodies.append(cylBody) }
+                if var boxBody { offsetBody(&boxBody, dx: 0, dy: 14, dz: 0); bodies.append(boxBody) }
+
+                if !ef.isParallel {
+                    let offset = SIMD3<Float>(0, 14, 0)
+                    let pe = SIMD3<Float>(Float(ef.pointOnEdge.x), Float(ef.pointOnEdge.y), Float(ef.pointOnEdge.z)) + offset
+                    let pf = SIMD3<Float>(Float(ef.pointOnFace.x), Float(ef.pointOnFace.y), Float(ef.pointOnFace.z)) + offset
+                    bodies.append(makeMarker(at: pe, radius: 0.2, id: "ef-pe", color: SIMD4(1, 0.3, 0.3, 1)))
+                    bodies.append(makeMarker(at: pf, radius: 0.2, id: "ef-pf", color: SIMD4(0.3, 1, 0.3, 1)))
+                    bodies.append(ViewportBody(
+                        id: "ef-line", vertexData: [], indices: [],
+                        edges: [[pe, pf]], color: SIMD4(1, 0.8, 0.2, 1)
+                    ))
+                    descriptions.append("EdgeFace: dist=\(String(format: "%.2f", ef.distance)) UV=(\(String(format: "%.2f", ef.faceUV.x)), \(String(format: "%.2f", ef.faceUV.y)))")
+                } else {
+                    descriptions.append("EdgeFace: parallel")
+                }
+            }
+        }
+
+        // --- Curve joining: join 3 edge curves into one BSpline ---
+        if let box = Shape.box(width: 6, height: 4, depth: 3) {
+            let edges = box.edges()
+            // Get curves from first 3 consecutive edges
+            var curves: [Curve3D] = []
+            for i in 0..<min(3, edges.count) {
+                if let c = edges[i].approximatedCurve() {
+                    curves.append(c)
+                }
+            }
+            if curves.count >= 2 {
+                // Show individual edge curves (before join)
+                for (i, curve) in curves.enumerated() {
+                    let pts = curve.samplePoints(first: 0, last: 1, maxPoints: 50)
+                    let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y) + 28, Float($0.z)) }
+                    if !floatPts.isEmpty {
+                        let colors: [SIMD4<Float>] = [
+                            SIMD4(1, 0.3, 0.3, 1), SIMD4(0.3, 1, 0.3, 1), SIMD4(0.3, 0.3, 1, 1)
+                        ]
+                        bodies.append(polylineToBody(floatPts, id: "curve-pre-\(i)",
+                                                     color: colors[i % colors.count]))
+                    }
+                }
+
+                // Try to join them
+                if let joined = Curve3D.joined(curves: curves) {
+                    let pts = joined.samplePoints(first: 0, last: 1, maxPoints: 100)
+                    let floatPts = pts.map { SIMD3<Float>(Float($0.x) + 14, Float($0.y) + 28, Float($0.z)) }
+                    if !floatPts.isEmpty {
+                        bodies.append(polylineToBody(floatPts, id: "curve-joined",
+                                                     color: SIMD4(1, 0.8, 0.2, 1)))
+                    }
+                    descriptions.append("CurveJoin: \(curves.count) curves → 1 BSpline")
+                }
+            }
+        }
+
+        // --- Curve analysis: project point and validate range ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6) {
+            let edges = box.edges()
+            if let firstEdge = edges.first,
+               let curve = firstEdge.approximatedCurve() {
+                // Project a point onto the curve
+                let testPt = SIMD3<Double>(5, 5, 0)
+                let proj = curve.projectPoint(testPt)
+
+                let offset = SIMD3<Float>(20, 0, 0)
+                let tp = SIMD3<Float>(Float(testPt.x), Float(testPt.y), Float(testPt.z)) + offset
+                let pp = SIMD3<Float>(Float(proj.point.x), Float(proj.point.y), Float(proj.point.z)) + offset
+                bodies.append(makeMarker(at: tp, radius: 0.25, id: "proj-test", color: SIMD4(1, 0.3, 0.3, 1)))
+                bodies.append(makeMarker(at: pp, radius: 0.25, id: "proj-pt", color: SIMD4(0.3, 1, 0.3, 1)))
+                bodies.append(ViewportBody(
+                    id: "proj-line", vertexData: [], indices: [],
+                    edges: [[tp, pp]], color: SIMD4(1, 0.8, 0.2, 1)
+                ))
+
+                // Show the curve
+                let samplePts = curve.samplePoints(first: 0, last: 1, maxPoints: 50)
+                let floatPts = samplePts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) + offset }
+                if !floatPts.isEmpty {
+                    bodies.append(polylineToBody(floatPts, id: "proj-curve", color: SIMD4(0.5, 0.7, 1, 1)))
+                }
+
+                // Validate range
+                let vr = curve.validateRange(first: -1.0, last: 2.0)
+                descriptions.append("CurveProject: dist=\(String(format: "%.2f", proj.distance)) param=\(String(format: "%.2f", proj.parameter))")
+                descriptions.append("ValidateRange: [\(String(format: "%.2f", vr.first)), \(String(format: "%.2f", vr.last))] adjusted=\(vr.wasAdjusted)")
+            }
+        }
+
+        // --- Surface UV projection: project 3D points onto a sphere surface ---
+        if let sphere = Shape.sphere(radius: 4) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sphere, id: "uv-sphere", color: SIMD4(0.5, 0.7, 0.9, 0.3), deflection: 0.05
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 42, dz: 0)
+                bodies.append(body)
+            }
+
+            // Create a Surface for UV projection
+            let surface = Surface.sphere(center: SIMD3(0, 0, 0), radius: 4)
+            if let surface {
+                let testPoints: [SIMD3<Double>] = [
+                    SIMD3(4, 0, 0), SIMD3(0, 4, 0), SIMD3(0, 0, 4),
+                    SIMD3(2.83, 2.83, 0), SIMD3(0, 2.83, 2.83)
+                ]
+                for (i, pt) in testPoints.enumerated() {
+                    let uv = surface.valueOfUV(point: pt)
+                    let marker = SIMD3<Float>(Float(pt.x), Float(pt.y) + 42, Float(pt.z))
+                    bodies.append(makeMarker(at: marker, radius: 0.3, id: "uv-pt-\(i)",
+                                             color: SIMD4(1, 0.4, 0.2, 1)))
+                    if i == 0 {
+                        descriptions.append("SurfaceUV: gap=\(String(format: "%.4f", uv.gap)) uv=(\(String(format: "%.2f", uv.uv.x)), \(String(format: "%.2f", uv.uv.y)))")
+                    }
+                }
+            }
+        }
+
+        // --- Free bounds analysis: analyze a shell with holes ---
+        if let box = Shape.box(width: 10, height: 10, depth: 10) {
+            // Create a shell by removing a face (using cut to punch a hole)
+            if let cyl = Shape.cylinder(radius: 2, height: 12),
+               let holed = box.subtracting(cyl) {
+                let analysis = holed.freeBoundsAnalysis(tolerance: 0.01)
+                descriptions.append("FreeBounds: total=\(analysis.totalCount) closed=\(analysis.closedCount) open=\(analysis.openCount)")
+
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    holed, id: "fb-shape", color: SIMD4(0.6, 0.8, 0.5, 0.7), deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 42, dz: 0)
+                    bodies.append(body)
+                }
+
+                // Show closed free bound wires if any
+                for i in 0..<analysis.closedCount {
+                    if let info = holed.closedFreeBoundInfo(tolerance: 0.01, index: i) {
+                        descriptions.append("  Bound \(i): area=\(String(format: "%.1f", info.area)) perim=\(String(format: "%.1f", info.perimeter)) notches=\(info.notchCount)")
+                    }
+                }
+            }
+        }
+
+        // --- BSpline restriction: simplify a filleted box ---
+        if let box = Shape.box(width: 6, height: 6, depth: 6),
+           let filleted = box.filleted(radius: 1.0) {
+            let edgesBefore = filleted.edges().count
+            if let simplified = filleted.bsplineRestriction(
+                tol3d: 0.1, maxDegree: 4, maxSegments: 20
+            ) {
+                let edgesAfter = simplified.edges().count
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    simplified, id: "bspline-restricted",
+                    color: SIMD4(0.8, 0.6, 0.4, 0.85), deflection: 0.05
+                )
+                if var body {
+                    offsetBody(&body, dx: 28, dy: 42, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("BSplineRestrict: edges \(edgesBefore)→\(edgesAfter) (maxDeg=4)")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: descriptions.joined(separator: "\n")
+        )
+    }
+
     private static func polylineToBody(
         _ points: [SIMD3<Float>],
         id: String,

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -2333,6 +2333,403 @@ enum OCCT8Gallery {
         )
     }
 
+    // MARK: - v0.42: Solid Construction, 2D Fillets, Polygon3D, Point Cloud
+
+    /// Demonstrates solidFromShells, polygon3D, fillet2D, chamfer2D, and analyzePointCloud.
+    static func solidAnd2DFillets() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- solidFromShells: hollow solid with cavity ---
+        if let outer = Shape.box(width: 10, height: 10, depth: 10),
+           let inner = Shape.box(width: 6, height: 6, depth: 6)?
+            .translated(by: SIMD3(2, 2, 2)) {
+            // Shell the outer and inner boxes
+            if let solid = Shape.solidFromShells([outer, inner]) {
+                // Section it to reveal the cavity
+                if let cutter = Shape.box(width: 12, height: 12, depth: 12)?
+                    .translated(by: SIMD3(-1, 5, -1)),
+                   let sectioned = solid.subtracting(cutter) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        sectioned, id: "solid-hollow", color: SIMD4(0.4, 0.6, 0.9, 0.9),
+                        deflection: 0.02
+                    )
+                    if let body { bodies.append(body) }
+                    descriptions.append("solidFromShells: hollow box")
+                } else {
+                    // Show the solid without section cut
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        solid, id: "solid-hollow", color: SIMD4(0.4, 0.6, 0.9, 0.7),
+                        deflection: 0.02
+                    )
+                    if let body { bodies.append(body) }
+                    descriptions.append("solidFromShells: hollow box (no section)")
+                }
+            }
+        }
+
+        // --- polygon3D: 3D star wire extruded into a prism ---
+        let starPoints: [SIMD3<Double>] = (0..<10).map { i in
+            let angle = Double(i) / 10.0 * 2.0 * .pi
+            let r: Double = i % 2 == 0 ? 4.0 : 2.0
+            return SIMD3(r * cos(angle), r * sin(angle), 0)
+        }
+        if let starWire = Wire.polygon3D(starPoints, closed: true) {
+            // Show the wire
+            var wireBody = wireToBody(starWire, id: "poly3d-wire",
+                                       color: SIMD4(1.0, 0.8, 0.2, 1.0))
+            offsetBody(&wireBody, dx: 16, dy: 0, dz: 0)
+            bodies.append(wireBody)
+
+            // Extrude into a prism
+            if let prism = Shape.extrude(profile: starWire, direction: SIMD3(0, 0, 1), length: 5) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    prism, id: "poly3d-prism", color: SIMD4(0.9, 0.7, 0.2, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 26, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+            descriptions.append("polygon3D: 10-pt star → prism")
+        }
+
+        // --- fillet2D: rounded corners on a rectangle ---
+        if let rectWire = Wire.rectangle(width: 10, height: 8),
+           let rectFace = Shape.face(from: rectWire) {
+            // Original rectangle
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                rectFace, id: "fillet2d-orig", color: SIMD4(0.6, 0.6, 0.6, 0.5),
+                deflection: 0.02
+            )
+            if var orig {
+                offsetBody(&orig, dx: 0, dy: 16, dz: 0)
+                bodies.append(orig)
+            }
+
+            // Fillet all 4 corners with different radii
+            if let filleted = rectFace.fillet2D(
+                vertexIndices: [0, 1, 2, 3],
+                radii: [1.0, 2.0, 1.0, 2.0]
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    filleted, id: "fillet2d-result", color: SIMD4(0.3, 0.8, 0.4, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 16, dz: 0)
+                    bodies.append(body)
+                }
+                let edgeCount = filleted.subShapeCount(ofType: .edge)
+                descriptions.append("fillet2D: 4→\(edgeCount) edges")
+            }
+        }
+
+        // --- chamfer2D: angled cuts on a square ---
+        if let sqWire = Wire.rectangle(width: 8, height: 8),
+           let sqFace = Shape.face(from: sqWire) {
+            // Chamfer one corner
+            if let chamfered = sqFace.chamfer2D(
+                edgePairs: [(0, 1)],
+                distances: [2.0]
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    chamfered, id: "chamfer2d-result", color: SIMD4(0.9, 0.5, 0.3, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 28, dy: 16, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("chamfer2D: 1 corner cut")
+            }
+        }
+
+        // --- analyzePointCloud: 4 classification scenarios ---
+        let classifications: [(String, [SIMD3<Double>], SIMD4<Float>)] = [
+            ("point", [SIMD3(0, 0, 0), SIMD3(0, 0, 0), SIMD3(0, 0, 0)],
+             SIMD4(1, 0.3, 0.3, 1)),
+            ("linear", [SIMD3(0, 0, 0), SIMD3(5, 0, 0), SIMD3(10, 0, 0)],
+             SIMD4(0.3, 1, 0.3, 1)),
+            ("planar", [SIMD3(0, 0, 0), SIMD3(5, 0, 0), SIMD3(5, 5, 0), SIMD3(0, 5, 0)],
+             SIMD4(0.3, 0.3, 1, 1)),
+            ("space", [SIMD3(0, 0, 0), SIMD3(5, 0, 0), SIMD3(0, 5, 0), SIMD3(0, 0, 5)],
+             SIMD4(0.9, 0.9, 0.3, 1)),
+        ]
+        for (ci, (label, pts, color)) in classifications.enumerated() {
+            let dx = Float(ci) * 8
+            // Show points as small markers
+            for (pi, p) in pts.enumerated() {
+                var marker = makeMarker(
+                    at: SIMD3(Float(p.x), Float(p.y), Float(p.z)),
+                    radius: 0.3, id: "ptcloud-\(label)-\(pi)", color: color
+                )
+                offsetBody(&marker, dx: dx, dy: 28, dz: 0)
+                bodies.append(marker)
+            }
+
+            if let result = Shape.analyzePointCloud(pts) {
+                switch result {
+                case .point:
+                    descriptions.append("\(label):coincident")
+                case .linear(let origin, let dir):
+                    // Draw the fit line
+                    let o = SIMD3<Float>(Float(origin.x), Float(origin.y), Float(origin.z))
+                    let d = SIMD3<Float>(Float(dir.x), Float(dir.y), Float(dir.z))
+                    let start = o - d * 2
+                    let end = o + d * 12
+                    var lineBody = ViewportBody(
+                        id: "ptcloud-\(label)-line", vertexData: [], indices: [],
+                        edges: [[start, end]], color: color
+                    )
+                    offsetBody(&lineBody, dx: dx, dy: 28, dz: 0)
+                    bodies.append(lineBody)
+                    descriptions.append("\(label):line")
+                case .planar(let origin, let normal):
+                    // Draw a normal vector
+                    let o = SIMD3<Float>(Float(origin.x), Float(origin.y), Float(origin.z))
+                    let n = SIMD3<Float>(Float(normal.x), Float(normal.y), Float(normal.z))
+                    var normalBody = ViewportBody(
+                        id: "ptcloud-\(label)-normal", vertexData: [], indices: [],
+                        edges: [[o, o + n * 3]], color: SIMD4(1, 0.5, 0.5, 1)
+                    )
+                    offsetBody(&normalBody, dx: dx, dy: 28, dz: 0)
+                    bodies.append(normalBody)
+                    descriptions.append("\(label):plane")
+                case .space:
+                    descriptions.append("\(label):3D")
+                }
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.42: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.43: BSpline Fill, Face Subdivision, Small Face Detection
+
+    /// Demonstrates bsplineFill (2-curve and 4-curve), dividedByArea, dividedByParts,
+    /// checkSmallFaces, and purgedLocations.
+    static func bsplineFillAndSubdivision() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // --- BSpline fill from 2 curves (3 fill styles side by side) ---
+        let c1 = Curve3D.interpolate(points: [
+            SIMD3(0, 0, 0), SIMD3(3, 0, 2), SIMD3(6, 0, 3), SIMD3(10, 0, 0)
+        ])
+        let c2 = Curve3D.interpolate(points: [
+            SIMD3(0, 8, 0), SIMD3(3, 8, -1), SIMD3(6, 8, 2), SIMD3(10, 8, 0)
+        ])
+
+        if let c1, let c2 {
+            let styles: [(Surface.FillStyle, String, SIMD4<Float>)] = [
+                (.stretch, "stretch", SIMD4(0.3, 0.7, 0.9, 0.85)),
+                (.coons, "coons", SIMD4(0.3, 0.9, 0.5, 0.85)),
+                (.curved, "curved", SIMD4(0.9, 0.6, 0.3, 0.85)),
+            ]
+            for (si, (style, name, color)) in styles.enumerated() {
+                let dx = Float(si) * 14
+                if let surface = Surface.bsplineFill(curve1: c1, curve2: c2, style: style) {
+                    let dom = surface.domain
+                    if let face = Shape.face(from: surface,
+                                              uRange: dom.uMin...dom.uMax,
+                                              vRange: dom.vMin...dom.vMax) {
+                        let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                            face, id: "bsfill2-\(name)", color: color,
+                            deflection: 0.02
+                        )
+                        if var body {
+                            offsetBody(&body, dx: dx, dy: 0, dz: 0)
+                            bodies.append(body)
+                        }
+                    }
+                }
+                // Show boundary curves as sampled polylines
+                let params1 = uniformParameters(curve: c1, count: 40)
+                let pts1 = c1.evaluateGrid(params1).map {
+                    SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z))
+                }
+                var w1 = polylineToBody(pts1, id: "bsfill2-c1-\(name)",
+                                        color: SIMD4(1, 1, 1, 1))
+                offsetBody(&w1, dx: dx, dy: 0, dz: 0)
+                bodies.append(w1)
+                let params2 = uniformParameters(curve: c2, count: 40)
+                let pts2 = c2.evaluateGrid(params2).map {
+                    SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z))
+                }
+                var w2 = polylineToBody(pts2, id: "bsfill2-c2-\(name)",
+                                        color: SIMD4(1, 1, 1, 1))
+                offsetBody(&w2, dx: dx, dy: 0, dz: 0)
+                bodies.append(w2)
+            }
+            descriptions.append("2-curve fill: stretch/coons/curved")
+        }
+
+        // --- BSpline fill from 4 curves (Coons patch) ---
+        let bottom = Curve3D.interpolate(points: [
+            SIMD3(0, 0, 0), SIMD3(4, 0, 2), SIMD3(8, 0, 0)
+        ])
+        let right = Curve3D.interpolate(points: [
+            SIMD3(8, 0, 0), SIMD3(8, 4, 3), SIMD3(8, 8, 0)
+        ])
+        let top = Curve3D.interpolate(points: [
+            SIMD3(8, 8, 0), SIMD3(4, 8, -1), SIMD3(0, 8, 0)
+        ])
+        let left = Curve3D.interpolate(points: [
+            SIMD3(0, 8, 0), SIMD3(0, 4, 1), SIMD3(0, 0, 0)
+        ])
+
+        if let b = bottom, let r = right, let t = top, let l = left {
+            if let surface = Surface.bsplineFill(curves: (b, r, t, l), style: .coons) {
+                let dom = surface.domain
+                if let face = Shape.face(from: surface,
+                                          uRange: dom.uMin...dom.uMax,
+                                          vRange: dom.vMin...dom.vMax) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        face, id: "bsfill4-coons", color: SIMD4(0.8, 0.4, 0.8, 0.85),
+                        deflection: 0.02
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 0, dy: 14, dz: 0)
+                        bodies.append(body)
+                    }
+                }
+            }
+            // Show boundary curves as sampled polylines
+            for (curve, label) in [(b, "b"), (r, "r"), (t, "t"), (l, "l")] {
+                let params = uniformParameters(curve: curve, count: 40)
+                let pts = curve.evaluateGrid(params).map {
+                    SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z))
+                }
+                var wb = polylineToBody(pts, id: "bsfill4-\(label)",
+                                        color: SIMD4(1, 1, 0.3, 1))
+                offsetBody(&wb, dx: 0, dy: 14, dz: 0)
+                bodies.append(wb)
+            }
+            descriptions.append("4-curve Coons patch")
+        }
+
+        // --- dividedByArea: box faces split by area threshold ---
+        if let box = Shape.box(width: 8, height: 8, depth: 8) {
+            let origFaceCount = box.subShapeCount(ofType: .face)
+
+            // Show original with per-face colors
+            let origFaces = box.subShapes(ofType: .face)
+            let faceColors: [SIMD4<Float>] = [
+                SIMD4(0.9, 0.4, 0.4, 0.7), SIMD4(0.4, 0.9, 0.4, 0.7),
+                SIMD4(0.4, 0.4, 0.9, 0.7), SIMD4(0.9, 0.9, 0.4, 0.7),
+                SIMD4(0.9, 0.4, 0.9, 0.7), SIMD4(0.4, 0.9, 0.9, 0.7),
+            ]
+            for (i, face) in origFaces.enumerated() {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    face, id: "divarea-orig-\(i)", color: faceColors[i % faceColors.count],
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 16, dy: 14, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Divide by area (each face is 64 sq units, max 20 should split each)
+            if let divided = box.dividedByArea(maxArea: 20) {
+                let newFaceCount = divided.subShapeCount(ofType: .face)
+                let divFaces = divided.subShapes(ofType: .face)
+                let moreColors: [SIMD4<Float>] = [
+                    SIMD4(0.9, 0.3, 0.3, 0.8), SIMD4(0.3, 0.9, 0.3, 0.8),
+                    SIMD4(0.3, 0.3, 0.9, 0.8), SIMD4(0.9, 0.9, 0.3, 0.8),
+                    SIMD4(0.9, 0.3, 0.9, 0.8), SIMD4(0.3, 0.9, 0.9, 0.8),
+                    SIMD4(0.9, 0.6, 0.3, 0.8), SIMD4(0.6, 0.3, 0.9, 0.8),
+                ]
+                for (i, face) in divFaces.enumerated() {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        face, id: "divarea-result-\(i)", color: moreColors[i % moreColors.count],
+                        deflection: 0.02
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 28, dy: 14, dz: 0)
+                        bodies.append(body)
+                    }
+                }
+                descriptions.append("dividedByArea: \(origFaceCount)→\(newFaceCount)F")
+            }
+        }
+
+        // --- dividedByParts: cylinder faces split into target parts ---
+        if let cyl = Shape.cylinder(radius: 4, height: 6) {
+            let origFaceCount = cyl.subShapeCount(ofType: .face)
+            let (orig, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "divparts-orig", color: SIMD4(0.6, 0.6, 0.6, 0.5),
+                deflection: 0.02
+            )
+            if var orig {
+                offsetBody(&orig, dx: 0, dy: 28, dz: 0)
+                bodies.append(orig)
+            }
+
+            if let divided = cyl.dividedByParts(4) {
+                let newFaceCount = divided.subShapeCount(ofType: .face)
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    divided, id: "divparts-result", color: SIMD4(0.5, 0.8, 0.6, 0.85),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 14, dy: 28, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("dividedByParts(4): \(origFaceCount)→\(newFaceCount)F")
+            }
+        }
+
+        // --- checkSmallFaces: create a shape with degenerate faces and detect them ---
+        if let sphere = Shape.sphere(radius: 3) {
+            let issues = sphere.checkSmallFaces()
+            if issues.isEmpty {
+                descriptions.append("checkSmallFaces(sphere): clean")
+            } else {
+                descriptions.append("checkSmallFaces(sphere): \(issues.count) issues")
+                // Highlight spot face locations
+                for (i, info) in issues.enumerated() {
+                    if let loc = info.spotLocation {
+                        var marker = makeMarker(
+                            at: SIMD3(Float(loc.x), Float(loc.y), Float(loc.z)),
+                            radius: 0.4, id: "smallface-\(i)",
+                            color: SIMD4(1, 0, 0, 1)
+                        )
+                        offsetBody(&marker, dx: 28, dy: 28, dz: 0)
+                        bodies.append(marker)
+                    }
+                }
+            }
+
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sphere, id: "smallface-sphere", color: SIMD4(0.7, 0.7, 0.8, 0.6),
+                deflection: 0.02
+            )
+            if var body {
+                offsetBody(&body, dx: 28, dy: 28, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        // --- purgedLocations: mirror creates negative scale, purge cleans it ---
+        if let box = Shape.box(width: 4, height: 4, depth: 4) {
+            if let mirrored = box.mirrored(planeNormal: SIMD3(1, 0, 0)) {
+                let hadPurge = mirrored.purgedLocations != nil
+                descriptions.append("purgedLocations: \(hadPurge ? "cleaned" : "already clean")")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.42-43: " + descriptions.joined(separator: " | ")
+        )
+    }
+
     // MARK: - Helpers
 
     private static func uniformParameters(curve: Curve3D, count: Int) -> [Double] {

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -1,0 +1,556 @@
+// OCCT8Gallery.swift
+// OCCTSwiftMetalDemo
+//
+// Demonstrates new OCCT 8.0.0-rc4 features from OCCTSwift v0.28 and v0.29.
+
+import Foundation
+import simd
+import OCCTSwift
+import OCCTSwiftViewport
+
+/// Gallery showcasing OCCT 8.0.0-rc4 features: helix curves, KD-tree queries,
+/// wedge primitives, hatch patterns, polynomial solvers, and shape operations.
+enum OCCT8Gallery {
+
+    // MARK: - v0.28: Helix Curves
+
+    /// Constant and tapered helical wires visualized as colored wireframes.
+    static func helixCurves() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Constant-radius helix (spring)
+        if let spring = Wire.helix(radius: 2.0, pitch: 1.0, turns: 8) {
+            bodies.append(wireToBody(spring, id: "helix-spring",
+                                     color: SIMD4(0.2, 0.6, 1.0, 1.0)))
+        }
+
+        // Tapered helix (cone coil) — offset to the right
+        if let taper = Wire.helixTapered(
+            origin: SIMD3(8, 0, 0),
+            startRadius: 3.0, endRadius: 0.5,
+            pitch: 1.5, turns: 6
+        ) {
+            bodies.append(wireToBody(taper, id: "helix-tapered",
+                                     color: SIMD4(1.0, 0.5, 0.1, 1.0)))
+        }
+
+        // Clockwise helix — offset left
+        if let cw = Wire.helix(
+            origin: SIMD3(-8, 0, 0),
+            radius: 1.5, pitch: 0.8, turns: 10, clockwise: true
+        ) {
+            bodies.append(wireToBody(cw, id: "helix-cw",
+                                     color: SIMD4(0.3, 0.9, 0.4, 1.0)))
+        }
+
+        // Tight thread-like helix
+        if let thread = Wire.helix(
+            origin: SIMD3(0, 8, 0),
+            radius: 1.0, pitch: 0.3, turns: 20
+        ) {
+            bodies.append(wireToBody(thread, id: "helix-thread",
+                                     color: SIMD4(0.9, 0.2, 0.6, 1.0)))
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Helix curves: constant spring, tapered coil, clockwise, thread"
+        )
+    }
+
+    // MARK: - v0.28: KD-Tree Spatial Queries
+
+    /// Builds a KD-tree from random points and visualizes nearest/range queries.
+    static func kdTreeQueries() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Generate a grid of points with some noise
+        var points: [SIMD3<Double>] = []
+        for ix in -5...5 {
+            for iy in -5...5 {
+                for iz in 0...2 {
+                    let noise = SIMD3<Double>(
+                        Double.random(in: -0.3...0.3),
+                        Double.random(in: -0.3...0.3),
+                        Double.random(in: -0.3...0.3)
+                    )
+                    points.append(SIMD3(Double(ix), Double(iy), Double(iz)) + noise)
+                }
+            }
+        }
+
+        // Render all points as small spheres (gray)
+        for (i, pt) in points.enumerated() {
+            let sphere = makeMarker(
+                at: SIMD3<Float>(Float(pt.x), Float(pt.y), Float(pt.z)),
+                radius: 0.08, id: "kd-pt-\(i)",
+                color: SIMD4(0.5, 0.5, 0.5, 0.6)
+            )
+            bodies.append(sphere)
+        }
+
+        guard let tree = KDTree(points: points) else {
+            return Curve2DGallery.GalleryResult(bodies: bodies, description: "KD-tree build failed")
+        }
+
+        // Query: nearest to origin
+        if let (idx, _) = tree.nearest(to: .zero) {
+            let pt = points[idx]
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(Float(pt.x), Float(pt.y), Float(pt.z)),
+                radius: 0.25, id: "kd-nearest",
+                color: SIMD4(1.0, 0.2, 0.2, 1.0)
+            ))
+        }
+
+        // Query: 5 nearest to (3, 3, 1)
+        let queryPt = SIMD3<Double>(3, 3, 1)
+        let kNearest = tree.kNearest(to: queryPt, k: 5)
+        for (i, result) in kNearest.enumerated() {
+            let pt = points[result.index]
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(Float(pt.x), Float(pt.y), Float(pt.z)),
+                radius: 0.2, id: "kd-knn-\(i)",
+                color: SIMD4(0.2, 1.0, 0.3, 1.0)
+            ))
+        }
+        // Mark query point
+        bodies.append(makeMarker(
+            at: SIMD3<Float>(Float(queryPt.x), Float(queryPt.y), Float(queryPt.z)),
+            radius: 0.15, id: "kd-query-knn",
+            color: SIMD4(1.0, 1.0, 0.0, 1.0)
+        ))
+
+        // Query: range search — all points within radius 2.0 of (-3, -3, 0)
+        let rangePt = SIMD3<Double>(-3, -3, 0)
+        let rangeResults = tree.rangeSearch(center: rangePt, radius: 2.0)
+        for (i, idx) in rangeResults.enumerated() {
+            let pt = points[idx]
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(Float(pt.x), Float(pt.y), Float(pt.z)),
+                radius: 0.18, id: "kd-range-\(i)",
+                color: SIMD4(0.3, 0.5, 1.0, 1.0)
+            ))
+        }
+        bodies.append(makeMarker(
+            at: SIMD3<Float>(Float(rangePt.x), Float(rangePt.y), Float(rangePt.z)),
+            radius: 0.15, id: "kd-query-range",
+            color: SIMD4(1.0, 0.5, 0.0, 1.0)
+        ))
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "KD-tree: \(points.count) pts, red=nearest, green=5-NN, blue=range(r=2)"
+        )
+    }
+
+    // MARK: - v0.29: Wedge Primitives
+
+    /// Wedge and advanced wedge shapes — tapered boxes, pyramids.
+    static func wedgePrimitives() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Simple wedge (tapered in X)
+        if let wedge = Shape.wedge(dx: 3, dy: 2, dz: 2, ltx: 1) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                wedge, id: "wedge-simple", color: SIMD4(0.5, 0.7, 0.9, 1.0)
+            )
+            if let body { bodies.append(body) }
+        }
+
+        // Pyramid (ltx = 0) — offset right
+        if let pyramid = Shape.wedge(dx: 2, dy: 3, dz: 2, ltx: 0) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                pyramid, id: "wedge-pyramid", color: SIMD4(0.9, 0.6, 0.3, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: 5, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        // Regular box (ltx = dx) for comparison — offset left
+        if let box = Shape.wedge(dx: 2, dy: 2, dz: 2, ltx: 2) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "wedge-box", color: SIMD4(0.6, 0.9, 0.6, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: -5, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        // Advanced wedge with custom top bounds — offset back
+        if let adv = Shape.wedge(dx: 4, dy: 2, dz: 4, xmin: 1, zmin: 1, xmax: 3, zmax: 3) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                adv, id: "wedge-advanced", color: SIMD4(0.8, 0.5, 0.8, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 0, dz: 6)
+                bodies.append(body)
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Wedge primitives: tapered, pyramid (ltx=0), box (ltx=dx), advanced"
+        )
+    }
+
+    // MARK: - v0.29: Hatch Patterns
+
+    /// 2D hatch patterns at various angles inside different boundary shapes.
+    static func hatchPatterns() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Rectangle boundary with horizontal hatching
+        let rect: [SIMD2<Double>] = [
+            SIMD2(0, 0), SIMD2(10, 0), SIMD2(10, 8), SIMD2(0, 8)
+        ]
+        let hHatch = HatchPattern.generate(
+            boundary: rect,
+            direction: SIMD2(1, 0),
+            spacing: 0.8
+        )
+        bodies.append(hatchToBody(hHatch, id: "hatch-horiz",
+                                   color: SIMD4(0.3, 0.6, 1.0, 1.0)))
+        bodies.append(boundaryToBody(rect, id: "hatch-rect-border",
+                                      color: SIMD4(0.9, 0.9, 0.9, 1.0)))
+
+        // Triangle boundary with 45-degree hatching — offset right
+        let tri: [SIMD2<Double>] = [
+            SIMD2(14, 0), SIMD2(24, 0), SIMD2(19, 8)
+        ]
+        let diagHatch = HatchPattern.generate(
+            boundary: tri,
+            direction: SIMD2(1, 1),
+            spacing: 0.6
+        )
+        bodies.append(hatchToBody(diagHatch, id: "hatch-diag",
+                                   color: SIMD4(1.0, 0.5, 0.2, 1.0)))
+        bodies.append(boundaryToBody(tri, id: "hatch-tri-border",
+                                      color: SIMD4(0.9, 0.9, 0.9, 1.0)))
+
+        // Hexagon boundary with vertical hatching — offset above
+        let hex = makeRegularPolygon(center: SIMD2(5, 18), radius: 4, sides: 6)
+        let vHatch = HatchPattern.generate(
+            boundary: hex,
+            direction: SIMD2(0, 1),
+            spacing: 0.5
+        )
+        bodies.append(hatchToBody(vHatch, id: "hatch-vert",
+                                   color: SIMD4(0.4, 0.9, 0.4, 1.0)))
+        bodies.append(boundaryToBody(hex, id: "hatch-hex-border",
+                                      color: SIMD4(0.9, 0.9, 0.9, 1.0)))
+
+        // Cross-hatch: two directions in same boundary — offset upper right
+        let crossRect: [SIMD2<Double>] = [
+            SIMD2(14, 12), SIMD2(24, 12), SIMD2(24, 20), SIMD2(14, 20)
+        ]
+        let h1 = HatchPattern.generate(boundary: crossRect, direction: SIMD2(1, 1), spacing: 0.7)
+        let h2 = HatchPattern.generate(boundary: crossRect, direction: SIMD2(1, -1), spacing: 0.7)
+        bodies.append(hatchToBody(h1, id: "hatch-cross1",
+                                   color: SIMD4(0.9, 0.3, 0.3, 1.0)))
+        bodies.append(hatchToBody(h2, id: "hatch-cross2",
+                                   color: SIMD4(0.3, 0.3, 0.9, 1.0)))
+        bodies.append(boundaryToBody(crossRect, id: "hatch-cross-border",
+                                      color: SIMD4(0.9, 0.9, 0.9, 1.0)))
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Hatch patterns: horizontal, 45°, vertical, cross-hatch"
+        )
+    }
+
+    // MARK: - v0.29: Shape Operations
+
+    /// Demonstrates NURBS conversion, fast sewing, and draft extrusion.
+    static func shapeOperations() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Original cylinder
+        if let cyl = Shape.cylinder(radius: 1.5, height: 4.0) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "op-original", color: SIMD4(0.6, 0.6, 0.6, 0.5)
+            )
+            if let body { bodies.append(body) }
+
+            // NURBS-converted version — offset right
+            if let nurbs = cyl.convertedToNURBS() {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    nurbs, id: "op-nurbs", color: SIMD4(0.3, 0.7, 1.0, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: 5, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Box + fast sewing demo: create faces and sew them
+        if let box = Shape.box(width: 3, height: 2, depth: 2) {
+            if let sewn = box.fastSewn() {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    sewn, id: "op-fastsewn", color: SIMD4(0.9, 0.6, 0.3, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: -5, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Wedge for variety — offset back
+        if let wedge = Shape.wedge(dx: 3, dy: 2, dz: 3, ltx: 0.5) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                wedge, id: "op-wedge", color: SIMD4(0.5, 0.9, 0.5, 1.0)
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 5, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Shape ops: original, NURBS conversion, fast sewing, wedge"
+        )
+    }
+
+    // MARK: - v0.29: Polynomial Solver
+
+    /// Visualizes roots of polynomial equations as curves with marked roots.
+    static func polynomialRoots() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Quadratic: x² - 5x + 6 = 0  →  roots at x=2, x=3
+        let quadRoots = PolynomialSolver.quadratic(a: 1, b: -5, c: 6)
+        let quadCurve = samplePolynomial(
+            { x in x * x - 5 * x + 6 },
+            xRange: -1...5, yOffset: 0
+        )
+        bodies.append(polylineToBody(quadCurve, id: "poly-quad",
+                                      color: SIMD4(0.3, 0.6, 1.0, 1.0)))
+        for (i, root) in quadRoots.roots.enumerated() {
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(Float(root), 0, 0),
+                radius: 0.15, id: "poly-quad-r\(i)",
+                color: SIMD4(1.0, 0.2, 0.2, 1.0)
+            ))
+        }
+
+        // Cubic: x³ - 6x² + 11x - 6 = 0  →  roots at x=1, 2, 3
+        let cubicRoots = PolynomialSolver.cubic(a: 1, b: -6, c: 11, d: -6)
+        let cubicCurve = samplePolynomial(
+            { x in x * x * x - 6 * x * x + 11 * x - 6 },
+            xRange: -0.5...4, yOffset: 8
+        )
+        bodies.append(polylineToBody(cubicCurve, id: "poly-cubic",
+                                      color: SIMD4(0.2, 0.9, 0.3, 1.0)))
+        for (i, root) in cubicRoots.roots.enumerated() {
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(Float(root), 8, 0),
+                radius: 0.15, id: "poly-cubic-r\(i)",
+                color: SIMD4(1.0, 0.2, 0.2, 1.0)
+            ))
+        }
+
+        // Quartic: x⁴ - 10x² + 9 = 0  →  roots at x=±1, ±3
+        let quarticRoots = PolynomialSolver.quartic(a: 1, b: 0, c: -10, d: 0, e: 9)
+        let quarticCurve = samplePolynomial(
+            { x in x * x * x * x - 10 * x * x + 9 },
+            xRange: -4...4, yOffset: 16, yScale: 0.1
+        )
+        bodies.append(polylineToBody(quarticCurve, id: "poly-quartic",
+                                      color: SIMD4(0.9, 0.4, 0.8, 1.0)))
+        for (i, root) in quarticRoots.roots.enumerated() {
+            bodies.append(makeMarker(
+                at: SIMD3<Float>(Float(root), 16, 0),
+                radius: 0.15, id: "poly-quartic-r\(i)",
+                color: SIMD4(1.0, 0.2, 0.2, 1.0)
+            ))
+        }
+
+        // X axis lines for reference
+        for yOff: Float in [0, 8, 16] {
+            let axis: [SIMD3<Float>] = [SIMD3(-5, yOff, 0), SIMD3(5, yOff, 0)]
+            bodies.append(ViewportBody(
+                id: "poly-axis-\(Int(yOff))",
+                vertexData: [], indices: [], edges: [axis],
+                color: SIMD4(0.4, 0.4, 0.4, 0.5)
+            ))
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "Polynomial roots: quadratic (2 roots), cubic (3), quartic (4). Red = roots."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func wireToBody(
+        _ wire: Wire,
+        id: String,
+        color: SIMD4<Float>
+    ) -> ViewportBody {
+        let edgeCount = wire.orderedEdgeCount
+        var polylines: [[SIMD3<Float>]] = []
+
+        for i in 0..<edgeCount {
+            if let pts = wire.orderedEdgePoints(at: i) {
+                let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+                if floatPts.count >= 2 {
+                    polylines.append(floatPts)
+                }
+            }
+        }
+
+        // Fallback: if orderedEdgePoints didn't work, wrap as Shape for edge extraction
+        if polylines.isEmpty, let shape = Shape.fromWire(wire) {
+            let count = shape.edgeCount
+            for i in 0..<count {
+                if let pts = shape.edgePolyline(at: i, deflection: 0.1) {
+                    let floatPts = pts.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+                    if floatPts.count >= 2 {
+                        polylines.append(floatPts)
+                    }
+                }
+            }
+        }
+
+        return ViewportBody(
+            id: id,
+            vertexData: [],
+            indices: [],
+            edges: polylines,
+            color: color
+        )
+    }
+
+    private static func makeMarker(
+        at position: SIMD3<Float>,
+        radius: Float,
+        id: String,
+        color: SIMD4<Float>
+    ) -> ViewportBody {
+        var sphere = ViewportBody.sphere(
+            id: id, radius: radius, segments: 8, rings: 4, color: color
+        )
+        let stride = 6
+        var verts: [Float] = []
+        verts.reserveCapacity(sphere.vertexData.count)
+        for i in Swift.stride(from: 0, to: sphere.vertexData.count, by: stride) {
+            verts.append(sphere.vertexData[i] + position.x)
+            verts.append(sphere.vertexData[i + 1] + position.y)
+            verts.append(sphere.vertexData[i + 2] + position.z)
+            verts.append(sphere.vertexData[i + 3])
+            verts.append(sphere.vertexData[i + 4])
+            verts.append(sphere.vertexData[i + 5])
+        }
+        sphere.vertexData = verts
+        return sphere
+    }
+
+    private static func offsetBody(_ body: inout ViewportBody, dx: Float, dy: Float, dz: Float) {
+        let stride = 6
+        var verts: [Float] = []
+        verts.reserveCapacity(body.vertexData.count)
+        for i in Swift.stride(from: 0, to: body.vertexData.count, by: stride) {
+            verts.append(body.vertexData[i] + dx)
+            verts.append(body.vertexData[i + 1] + dy)
+            verts.append(body.vertexData[i + 2] + dz)
+            verts.append(body.vertexData[i + 3])
+            verts.append(body.vertexData[i + 4])
+            verts.append(body.vertexData[i + 5])
+        }
+        body.vertexData = verts
+        body.edges = body.edges.map { polyline in
+            polyline.map { p in SIMD3(p.x + dx, p.y + dy, p.z + dz) }
+        }
+    }
+
+    private static func hatchToBody(
+        _ segments: [HatchSegment],
+        id: String,
+        color: SIMD4<Float>
+    ) -> ViewportBody {
+        let polylines: [[SIMD3<Float>]] = segments.map { seg in
+            [
+                SIMD3<Float>(Float(seg.start.x), Float(seg.start.y), 0),
+                SIMD3<Float>(Float(seg.end.x), Float(seg.end.y), 0),
+            ]
+        }
+        return ViewportBody(
+            id: id,
+            vertexData: [],
+            indices: [],
+            edges: polylines,
+            color: color
+        )
+    }
+
+    private static func boundaryToBody(
+        _ boundary: [SIMD2<Double>],
+        id: String,
+        color: SIMD4<Float>
+    ) -> ViewportBody {
+        var polyline: [SIMD3<Float>] = boundary.map {
+            SIMD3<Float>(Float($0.x), Float($0.y), 0)
+        }
+        // Close the loop
+        if let first = polyline.first {
+            polyline.append(first)
+        }
+        return ViewportBody(
+            id: id,
+            vertexData: [],
+            indices: [],
+            edges: [polyline],
+            color: color
+        )
+    }
+
+    private static func makeRegularPolygon(
+        center: SIMD2<Double>,
+        radius: Double,
+        sides: Int
+    ) -> [SIMD2<Double>] {
+        (0..<sides).map { i in
+            let angle = Double(i) / Double(sides) * 2 * .pi
+            return SIMD2(
+                center.x + radius * cos(angle),
+                center.y + radius * sin(angle)
+            )
+        }
+    }
+
+    private static func samplePolynomial(
+        _ f: (Double) -> Double,
+        xRange: ClosedRange<Double>,
+        yOffset: Double,
+        yScale: Double = 1.0
+    ) -> [SIMD3<Float>] {
+        let steps = 200
+        let dx = (xRange.upperBound - xRange.lowerBound) / Double(steps)
+        return (0...steps).map { i in
+            let x = xRange.lowerBound + Double(i) * dx
+            let y = yOffset + f(x) * yScale
+            return SIMD3<Float>(Float(x), Float(y), 0)
+        }
+    }
+
+    private static func polylineToBody(
+        _ points: [SIMD3<Float>],
+        id: String,
+        color: SIMD4<Float>
+    ) -> ViewportBody {
+        ViewportBody(
+            id: id,
+            vertexData: [],
+            indices: [],
+            edges: [points],
+            color: color
+        )
+    }
+}

--- a/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
+++ b/Sources/OCCTSwiftMetalDemo/OCCT8Gallery.swift
@@ -1597,6 +1597,287 @@ enum OCCT8Gallery {
         )
     }
 
+    // MARK: - v0.35: Cylindrical Projection & Multi-Offset
+
+    /// Demonstrates cylindrical wire projection onto a surface and multi-offset wires.
+    static func projectionAndOffset() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Cylindrical projection: project a circle wire onto a sphere
+        if let sphere = Shape.sphere(radius: 3),
+           let circleWire = Wire.circle(radius: 2),
+           let circleShape = Shape.fromWire(circleWire) {
+
+            // Show the sphere
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                sphere, id: "proj-sphere", color: SIMD4(0.6, 0.6, 0.6, 0.4),
+                deflection: 0.02
+            )
+            if let body { bodies.append(body) }
+
+            // Project circle onto sphere along Z
+            if let projected = Shape.projectWire(circleShape, onto: sphere,
+                                                  direction: SIMD3(0, 0, 1)) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    projected, id: "proj-result", color: SIMD4(1.0, 0.2, 0.2, 1.0),
+                    deflection: 0.02
+                )
+                if let body { bodies.append(body) }
+            }
+        }
+
+        // Multi-offset wires from a face
+        if let box = Shape.box(width: 6, height: 0.1, depth: 6) {
+            // Show the face
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "moff-face", color: SIMD4(0.5, 0.5, 0.5, 0.3)
+            )
+            if var body {
+                offsetBody(&body, dx: 10, dy: 0, dz: 0)
+                bodies.append(body)
+            }
+
+            // Generate concentric offset wires (like CNC toolpaths)
+            let offsets = box.multiOffsetWires(offsets: [-0.5, -1.0, -1.5, -2.0, -2.5])
+            let offsetColors: [SIMD4<Float>] = [
+                SIMD4(0.3, 0.7, 1.0, 1.0), SIMD4(0.3, 0.9, 0.4, 1.0),
+                SIMD4(0.9, 0.5, 0.3, 1.0), SIMD4(0.8, 0.4, 0.8, 1.0),
+                SIMD4(1.0, 0.8, 0.2, 1.0)
+            ]
+            for (i, wire) in offsets.enumerated() {
+                var wireBody = wireToBody(wire, id: "moff-\(i)",
+                                          color: offsetColors[i % offsetColors.count])
+                offsetBody(&wireBody, dx: 10, dy: 0, dz: 0)
+                bodies.append(wireBody)
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.35: Wire projection onto sphere (red), multi-offset toolpaths (right)"
+        )
+    }
+
+    // MARK: - v0.36: Face Division & Conical Projection
+
+    /// Demonstrates face subdivision and conical (point-source) projection.
+    static func faceDivision() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Face division: split cylinder faces into patches
+        if let cyl = Shape.cylinder(radius: 2, height: 4) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                cyl, id: "div-orig", color: SIMD4(0.6, 0.6, 0.6, 0.5),
+                deflection: 0.02
+            )
+            if let body { bodies.append(body) }
+
+            // Divide into ~4 patches per face
+            if let divided = cyl.dividedByNumber(4) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    divided, id: "div-result", color: SIMD4(0.3, 0.7, 1.0, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 7, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+
+                let origC = cyl.contents
+                let divC = divided.contents
+                _ = (origC, divC)
+            }
+        }
+
+        // Conical projection: project circle from a point onto a box
+        if let box = Shape.box(width: 6, height: 6, depth: 1),
+           let circleWire = Wire.circle(radius: 1.5),
+           let circleShape = Shape.fromWire(circleWire) {
+
+            let (b, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "cone-box", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if var b {
+                offsetBody(&b, dx: 16, dy: 0, dz: 0)
+                bodies.append(b)
+            }
+
+            // Project from eye point (like a flashlight)
+            if let projected = Shape.projectWireConical(
+                circleShape, onto: box, eye: SIMD3(0, 0, 10)
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    projected, id: "cone-proj", color: SIMD4(1.0, 0.3, 0.3, 1.0)
+                )
+                if var body {
+                    offsetBody(&body, dx: 16, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Show eye point
+            var eye = makeMarker(at: SIMD3(0, 0, 10), radius: 0.2, id: "cone-eye",
+                                 color: SIMD4(1.0, 1.0, 0.0, 1.0))
+            offsetBody(&eye, dx: 16, dy: 0, dz: 0)
+            bodies.append(eye)
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.36: Face division (blue, more patches), conical projection from eye (right)"
+        )
+    }
+
+    // MARK: - v0.37: Hollow Solid & Wire Analysis
+
+    /// Demonstrates hollowing (thick solid) and wire topology analysis.
+    static func hollowAndAnalysis() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+        var descriptions: [String] = []
+
+        // Hollow box: remove top face, create shell with wall thickness
+        if let box = Shape.box(width: 4, height: 4, depth: 4) {
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "hollow-orig", color: SIMD4(0.6, 0.6, 0.6, 0.4)
+            )
+            if let body { bodies.append(body) }
+
+            // Try removing face 2 (typically top face) with 0.3 wall thickness
+            for faceIdx in 0..<box.contents.faces {
+                if let hollowed = box.hollowed(removingFaces: [faceIdx], thickness: 0.3) {
+                    let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                        hollowed, id: "hollow-result", color: SIMD4(0.3, 0.7, 1.0, 0.9)
+                    )
+                    if var body {
+                        offsetBody(&body, dx: 8, dy: 0, dz: 0)
+                        bodies.append(body)
+                    }
+                    descriptions.append("Hollowed: face \(faceIdx) removed")
+                    break
+                }
+            }
+        }
+
+        // Multi-tool common: intersection of 3 cylinders
+        if let c1 = Shape.cylinder(radius: 2, height: 6),
+           let c2 = Shape.cylinder(radius: 2, height: 6)?.rotated(axis: SIMD3(1, 0, 0), angle: .pi / 2),
+           let c3 = Shape.cylinder(radius: 2, height: 6)?.rotated(axis: SIMD3(0, 1, 0), angle: .pi / 2) {
+
+            if let common = Shape.commonAll([c1, c2, c3]) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    common, id: "common-result", color: SIMD4(0.9, 0.5, 0.3, 0.9),
+                    deflection: 0.02
+                )
+                if var body {
+                    offsetBody(&body, dx: 16, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+                descriptions.append("commonAll: 3 cylinders")
+            }
+        }
+
+        // Wire analysis demo
+        if let wire = Wire.circle(radius: 2) {
+            if let analysis = wire.analyze() {
+                descriptions.append("Wire: closed=\(analysis.isClosed), edges=\(analysis.edgeCount)")
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.37: " + descriptions.joined(separator: " | ")
+        )
+    }
+
+    // MARK: - v0.38: OBB, Fuse-and-Blend, Evolving Fillet
+
+    /// Demonstrates oriented bounding box, fuse-and-blend, and evolving fillet.
+    static func obbAndBlend() -> Curve2DGallery.GalleryResult {
+        var bodies: [ViewportBody] = []
+
+        // Oriented Bounding Box on a rotated shape
+        if let box = Shape.box(width: 4, height: 2, depth: 1),
+           let rotated = box.rotated(axis: SIMD3(0, 0, 1), angle: .pi / 6) {
+
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                rotated, id: "obb-shape", color: SIMD4(0.3, 0.7, 1.0, 0.8)
+            )
+            if let body { bodies.append(body) }
+
+            // Show OBB as wireframe
+            if let corners = rotated.orientedBoundingBoxCorners(optimal: true) {
+                let fc = corners.map { SIMD3<Float>(Float($0.x), Float($0.y), Float($0.z)) }
+                if fc.count == 8 {
+                    // 8 corners: draw 12 edges of the box
+                    let edges: [[SIMD3<Float>]] = [
+                        [fc[0], fc[1]], [fc[1], fc[3]], [fc[3], fc[2]], [fc[2], fc[0]],
+                        [fc[4], fc[5]], [fc[5], fc[7]], [fc[7], fc[6]], [fc[6], fc[4]],
+                        [fc[0], fc[4]], [fc[1], fc[5]], [fc[2], fc[6]], [fc[3], fc[7]]
+                    ]
+                    bodies.append(ViewportBody(id: "obb-box", vertexData: [], indices: [], edges: edges,
+                                               color: SIMD4(1.0, 0.8, 0.0, 1.0)))
+                }
+            }
+        }
+
+        // Fuse and Blend: union two shapes with automatic fillet at intersection
+        if let box = Shape.box(width: 3, height: 3, depth: 3),
+           let cyl = Shape.cylinder(radius: 1.2, height: 5)?.translated(by: SIMD3(1.5, 0, -1)) {
+
+            if let blended = box.fusedAndBlended(with: cyl, radius: 0.3) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    blended, id: "blend-fuse", color: SIMD4(0.3, 0.9, 0.4, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 9, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Cut and blend for comparison
+            if let blended = box.cutAndBlended(with: cyl, radius: 0.2) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    blended, id: "blend-cut", color: SIMD4(0.9, 0.5, 0.3, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 18, dy: 0, dz: 0)
+                    bodies.append(body)
+                }
+            }
+        }
+
+        // Per-face variable offset
+        if let box = Shape.box(width: 3, height: 3, depth: 3) {
+            // Offset different faces by different amounts
+            if let varOffset = box.offsetPerFace(
+                defaultOffset: 0.2,
+                faceOffsets: [1: 0.8, 3: 0.5]
+            ) {
+                let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                    varOffset, id: "varoff", color: SIMD4(0.8, 0.4, 0.8, 0.9)
+                )
+                if var body {
+                    offsetBody(&body, dx: 0, dy: 8, dz: 0)
+                    bodies.append(body)
+                }
+            }
+
+            // Show original for reference
+            let (body, _) = CADFileLoader.shapeToBodyAndMetadata(
+                box, id: "varoff-orig", color: SIMD4(0.6, 0.6, 0.6, 0.3)
+            )
+            if var body {
+                offsetBody(&body, dx: 0, dy: 8, dz: 0)
+                bodies.append(body)
+            }
+        }
+
+        return Curve2DGallery.GalleryResult(
+            bodies: bodies,
+            description: "v0.38: OBB (yellow wireframe), fuse+blend (green), cut+blend (orange), variable offset (purple)"
+        )
+    }
+
     // MARK: - Helpers
 
     private static func uniformParameters(curve: Curve3D, count: Int) -> [Double] {

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -530,6 +530,7 @@ struct SpikeView: View {
 
     private enum OCCT8Demo {
         case helixCurves, kdTree, wedges, hatchPatterns, shapeOps, polynomials
+        case transformOps, shapeAnalysis, intersections, volumeOps
     }
 
     private var occt8DemoSection: some View {
@@ -540,6 +541,10 @@ struct SpikeView: View {
             Button("Hatch Patterns") { loadOCCT8Demo(.hatchPatterns) }
             Button("Shape Operations") { loadOCCT8Demo(.shapeOps) }
             Button("Polynomial Roots") { loadOCCT8Demo(.polynomials) }
+            Button("Transforms & Offset") { loadOCCT8Demo(.transformOps) }
+            Button("Shape Analysis") { loadOCCT8Demo(.shapeAnalysis) }
+            Button("Intersection Analysis") { loadOCCT8Demo(.intersections) }
+            Button("Volume & Connected") { loadOCCT8Demo(.volumeOps) }
         }
     }
 
@@ -562,6 +567,14 @@ struct SpikeView: View {
         case .polynomials:
             result = OCCT8Gallery.polynomialRoots()
             useTopView = true
+        case .transformOps:
+            result = OCCT8Gallery.transformOps()
+        case .shapeAnalysis:
+            result = OCCT8Gallery.shapeAnalysis()
+        case .intersections:
+            result = OCCT8Gallery.intersectionAnalysis()
+        case .volumeOps:
+            result = OCCT8Gallery.volumeOps()
         }
 
         bodies = result.bodies
@@ -832,7 +845,7 @@ struct SpikeView: View {
 
             VStack(alignment: .leading) {
                 Text("Edge Intensity: \(controller.edgeIntensity, specifier: "%.1f")")
-                Slider(value: $controller.edgeIntensity, in: 0.5...3.0)
+                Slider(value: $controller.edgeIntensity, in: 0.5...10.0)
             }
         }
     }

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -545,6 +545,7 @@ struct SpikeView: View {
     private enum OCCT8Demo {
         case helixCurves, kdTree, wedges, hatchPatterns, shapeOps, polynomials
         case transformOps, shapeAnalysis, intersections, volumeOps
+        case quasiUniform, bezierFill, revolution, linearRib
     }
 
     private var occt8DemoSection: some View {
@@ -559,6 +560,10 @@ struct SpikeView: View {
             Button("Shape Analysis") { loadOCCT8Demo(.shapeAnalysis) }
             Button("Intersection Analysis") { loadOCCT8Demo(.intersections) }
             Button("Volume & Connected") { loadOCCT8Demo(.volumeOps) }
+            Button("Curve Sampling") { loadOCCT8Demo(.quasiUniform) }
+            Button("Bezier Surface Fill") { loadOCCT8Demo(.bezierFill) }
+            Button("Revolution from Curve") { loadOCCT8Demo(.revolution) }
+            Button("Linear Rib") { loadOCCT8Demo(.linearRib) }
         }
     }
 
@@ -589,6 +594,14 @@ struct SpikeView: View {
             result = OCCT8Gallery.intersectionAnalysis()
         case .volumeOps:
             result = OCCT8Gallery.volumeOps()
+        case .quasiUniform:
+            result = OCCT8Gallery.quasiUniformSampling()
+        case .bezierFill:
+            result = OCCT8Gallery.bezierSurfaceFill()
+        case .revolution:
+            result = OCCT8Gallery.revolutionDemo()
+        case .linearRib:
+            result = OCCT8Gallery.linearRibDemo()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -556,6 +556,8 @@ struct SpikeView: View {
         case orientedBoundingBox, fuseAndBlend, variableOffset
         case freeBoundsAndFeatures, inertiaAndDistance, surgeryAndDetection
         case solidAnd2DFillets, bsplineFillAndSubdivision
+        case extremaAndArcs
+        case fillingAndSelfIntersection, concavityAndInertia
     }
 
     private var occt8DemoSection: some View {
@@ -595,6 +597,9 @@ struct SpikeView: View {
             Button("Surgery & Detection") { loadOCCT8Demo(.surgeryAndDetection) }
             Button("Solid & 2D Fillets") { loadOCCT8Demo(.solidAnd2DFillets) }
             Button("BSpline Fill & Subdivision") { loadOCCT8Demo(.bsplineFillAndSubdivision) }
+            Button("Extrema & Arcs") { loadOCCT8Demo(.extremaAndArcs) }
+            Button("Filling & Self-Intersection") { loadOCCT8Demo(.fillingAndSelfIntersection) }
+            Button("Concavity & Inertia") { loadOCCT8Demo(.concavityAndInertia) }
         }
     }
 
@@ -675,6 +680,12 @@ struct SpikeView: View {
             result = OCCT8Gallery.solidAnd2DFillets()
         case .bsplineFillAndSubdivision:
             result = OCCT8Gallery.bsplineFillAndSubdivision()
+        case .extremaAndArcs:
+            result = OCCT8Gallery.extremaAndArcs()
+        case .fillingAndSelfIntersection:
+            result = OCCT8Gallery.fillingAndSelfIntersection()
+        case .concavityAndInertia:
+            result = OCCT8Gallery.concavityAndInertia()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -551,6 +551,7 @@ struct SpikeView: View {
         case sectionAndValidation, shapeRepair, multiFuse, splitFaceByWire
         case projectionAndOffset, faceDivision, hollowAndAnalysis
         case orientedBoundingBox, fuseAndBlend, variableOffset
+        case freeBoundsAndFeatures, inertiaAndDistance, surgeryAndDetection
     }
 
     private var occt8DemoSection: some View {
@@ -585,6 +586,9 @@ struct SpikeView: View {
             Button("Oriented Bounding Box") { loadOCCT8Demo(.orientedBoundingBox) }
             Button("Fuse & Blend") { loadOCCT8Demo(.fuseAndBlend) }
             Button("Variable Offset") { loadOCCT8Demo(.variableOffset) }
+            Button("Free Bounds & Features") { loadOCCT8Demo(.freeBoundsAndFeatures) }
+            Button("Inertia & Distance") { loadOCCT8Demo(.inertiaAndDistance) }
+            Button("Surgery & Detection") { loadOCCT8Demo(.surgeryAndDetection) }
         }
     }
 
@@ -655,6 +659,12 @@ struct SpikeView: View {
             result = OCCT8Gallery.fuseAndBlend()
         case .variableOffset:
             result = OCCT8Gallery.variableOffset()
+        case .freeBoundsAndFeatures:
+            result = OCCT8Gallery.freeBoundsAndFeatures()
+        case .inertiaAndDistance:
+            result = OCCT8Gallery.inertiaAndDistance()
+        case .surgeryAndDetection:
+            result = OCCT8Gallery.surgeryAndDetection()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -558,6 +558,7 @@ struct SpikeView: View {
         case solidAnd2DFillets, bsplineFillAndSubdivision
         case extremaAndArcs
         case fillingAndSelfIntersection, concavityAndInertia
+        case localOpsAndValidation, splitOpsAndExtrema
     }
 
     private var occt8DemoSection: some View {
@@ -600,6 +601,8 @@ struct SpikeView: View {
             Button("Extrema & Arcs") { loadOCCT8Demo(.extremaAndArcs) }
             Button("Filling & Self-Intersection") { loadOCCT8Demo(.fillingAndSelfIntersection) }
             Button("Concavity & Inertia") { loadOCCT8Demo(.concavityAndInertia) }
+            Button("Local Ops & Validation") { loadOCCT8Demo(.localOpsAndValidation) }
+            Button("Split Ops & Extrema") { loadOCCT8Demo(.splitOpsAndExtrema) }
         }
     }
 
@@ -686,6 +689,10 @@ struct SpikeView: View {
             result = OCCT8Gallery.fillingAndSelfIntersection()
         case .concavityAndInertia:
             result = OCCT8Gallery.concavityAndInertia()
+        case .localOpsAndValidation:
+            result = OCCT8Gallery.localOpsAndValidation()
+        case .splitOpsAndExtrema:
+            result = OCCT8Gallery.splitOpsAndExtrema()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -555,6 +555,7 @@ struct SpikeView: View {
         case projectionAndOffset, faceDivision, hollowAndAnalysis
         case orientedBoundingBox, fuseAndBlend, variableOffset
         case freeBoundsAndFeatures, inertiaAndDistance, surgeryAndDetection
+        case solidAnd2DFillets, bsplineFillAndSubdivision
     }
 
     private var occt8DemoSection: some View {
@@ -592,6 +593,8 @@ struct SpikeView: View {
             Button("Free Bounds & Features") { loadOCCT8Demo(.freeBoundsAndFeatures) }
             Button("Inertia & Distance") { loadOCCT8Demo(.inertiaAndDistance) }
             Button("Surgery & Detection") { loadOCCT8Demo(.surgeryAndDetection) }
+            Button("Solid & 2D Fillets") { loadOCCT8Demo(.solidAnd2DFillets) }
+            Button("BSpline Fill & Subdivision") { loadOCCT8Demo(.bsplineFillAndSubdivision) }
         }
     }
 
@@ -668,6 +671,10 @@ struct SpikeView: View {
             result = OCCT8Gallery.inertiaAndDistance()
         case .surgeryAndDetection:
             result = OCCT8Gallery.surgeryAndDetection()
+        case .solidAnd2DFillets:
+            result = OCCT8Gallery.solidAnd2DFillets()
+        case .bsplineFillAndSubdivision:
+            result = OCCT8Gallery.bsplineFillAndSubdivision()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -546,6 +546,9 @@ struct SpikeView: View {
         case helixCurves, kdTree, wedges, hatchPatterns, shapeOps, polynomials
         case transformOps, shapeAnalysis, intersections, volumeOps
         case quasiUniform, bezierFill, revolution, linearRib
+        case asymmetricChamfer, loftAdvanced, offsetByJoin, featureOps
+        case pipeTransitions, faceFromSurface
+        case sectionAndValidation, shapeRepair, multiFuse, splitFaceByWire
     }
 
     private var occt8DemoSection: some View {
@@ -564,6 +567,16 @@ struct SpikeView: View {
             Button("Bezier Surface Fill") { loadOCCT8Demo(.bezierFill) }
             Button("Revolution from Curve") { loadOCCT8Demo(.revolution) }
             Button("Linear Rib") { loadOCCT8Demo(.linearRib) }
+            Button("Asymmetric Chamfer") { loadOCCT8Demo(.asymmetricChamfer) }
+            Button("Loft Advanced") { loadOCCT8Demo(.loftAdvanced) }
+            Button("Offset by Join") { loadOCCT8Demo(.offsetByJoin) }
+            Button("Feature Ops") { loadOCCT8Demo(.featureOps) }
+            Button("Pipe Transitions") { loadOCCT8Demo(.pipeTransitions) }
+            Button("Face from Surface") { loadOCCT8Demo(.faceFromSurface) }
+            Button("Section & Validation") { loadOCCT8Demo(.sectionAndValidation) }
+            Button("Shape Repair") { loadOCCT8Demo(.shapeRepair) }
+            Button("Multi-Fuse") { loadOCCT8Demo(.multiFuse) }
+            Button("Split Face by Wire") { loadOCCT8Demo(.splitFaceByWire) }
         }
     }
 
@@ -602,6 +615,26 @@ struct SpikeView: View {
             result = OCCT8Gallery.revolutionDemo()
         case .linearRib:
             result = OCCT8Gallery.linearRibDemo()
+        case .asymmetricChamfer:
+            result = OCCT8Gallery.asymmetricChamfer()
+        case .loftAdvanced:
+            result = OCCT8Gallery.loftAdvanced()
+        case .offsetByJoin:
+            result = OCCT8Gallery.offsetByJoin()
+        case .featureOps:
+            result = OCCT8Gallery.featureOps()
+        case .pipeTransitions:
+            result = OCCT8Gallery.pipeTransitions()
+        case .faceFromSurface:
+            result = OCCT8Gallery.faceFromSurface()
+        case .sectionAndValidation:
+            result = OCCT8Gallery.sectionAndValidation()
+        case .shapeRepair:
+            result = OCCT8Gallery.shapeRepair()
+        case .multiFuse:
+            result = OCCT8Gallery.multiFuse()
+        case .splitFaceByWire:
+            result = OCCT8Gallery.splitFaceByWire()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -559,6 +559,7 @@ struct SpikeView: View {
         case extremaAndArcs
         case fillingAndSelfIntersection, concavityAndInertia
         case localOpsAndValidation, splitOpsAndExtrema
+        case extremaAndCurveAnalysis
     }
 
     private var occt8DemoSection: some View {
@@ -603,6 +604,7 @@ struct SpikeView: View {
             Button("Concavity & Inertia") { loadOCCT8Demo(.concavityAndInertia) }
             Button("Local Ops & Validation") { loadOCCT8Demo(.localOpsAndValidation) }
             Button("Split Ops & Extrema") { loadOCCT8Demo(.splitOpsAndExtrema) }
+            Button("Extrema & Curve Analysis") { loadOCCT8Demo(.extremaAndCurveAnalysis) }
         }
     }
 
@@ -693,6 +695,8 @@ struct SpikeView: View {
             result = OCCT8Gallery.localOpsAndValidation()
         case .splitOpsAndExtrema:
             result = OCCT8Gallery.splitOpsAndExtrema()
+        case .extremaAndCurveAnalysis:
+            result = OCCT8Gallery.extremaAndCurveAnalysis()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -185,6 +185,7 @@ struct SpikeView: View {
             medialAxisDemoSection
             namingDemoSection
             annotationDemoSection
+            occt8DemoSection
             gdtSection
             selectionModeSection
             selectionSection
@@ -523,6 +524,59 @@ struct SpikeView: View {
         proximityInfo = nil
         focusOnBounds()
         controller.goToStandardView(.isometricFrontRight)
+    }
+
+    // MARK: - OCCT 8 Demo Section
+
+    private enum OCCT8Demo {
+        case helixCurves, kdTree, wedges, hatchPatterns, shapeOps, polynomials
+    }
+
+    private var occt8DemoSection: some View {
+        Section("OCCT 8 Features") {
+            Button("Helix Curves") { loadOCCT8Demo(.helixCurves) }
+            Button("KD-Tree Queries") { loadOCCT8Demo(.kdTree) }
+            Button("Wedge Primitives") { loadOCCT8Demo(.wedges) }
+            Button("Hatch Patterns") { loadOCCT8Demo(.hatchPatterns) }
+            Button("Shape Operations") { loadOCCT8Demo(.shapeOps) }
+            Button("Polynomial Roots") { loadOCCT8Demo(.polynomials) }
+        }
+    }
+
+    private func loadOCCT8Demo(_ demo: OCCT8Demo) {
+        let result: Curve2DGallery.GalleryResult
+        var useTopView = false
+
+        switch demo {
+        case .helixCurves:
+            result = OCCT8Gallery.helixCurves()
+        case .kdTree:
+            result = OCCT8Gallery.kdTreeQueries()
+        case .wedges:
+            result = OCCT8Gallery.wedgePrimitives()
+        case .hatchPatterns:
+            result = OCCT8Gallery.hatchPatterns()
+            useTopView = true
+        case .shapeOps:
+            result = OCCT8Gallery.shapeOperations()
+        case .polynomials:
+            result = OCCT8Gallery.polynomialRoots()
+            useTopView = true
+        }
+
+        bodies = result.bodies
+        cadMetadata = [:]
+        loadedShapes = []
+        originalColors = [:]
+        for body in bodies {
+            originalColors[body.id] = body.color
+        }
+        selectionManager.clearSelection()
+        controller.clearSelection()
+        operationStatus = result.description
+        proximityInfo = nil
+        focusOnBounds()
+        controller.goToStandardView(useTopView ? .top : .isometricFrontRight)
     }
 
     // MARK: - Projection Demo Section

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -140,6 +140,7 @@ struct SpikeView: View {
             sidebar
         } detail: {
             MetalViewportView(controller: controller, bodies: $bodies)
+                .overlay(alignment: .bottom) { statusOverlay }
         }
         #else
         MetalViewportView(controller: controller, bodies: $bodies)
@@ -154,6 +155,7 @@ struct SpikeView: View {
                 }
                 .padding(12)
             }
+            .overlay(alignment: .bottom) { statusOverlay }
             .sheet(isPresented: $showSettings) {
                 NavigationStack {
                     sidebar
@@ -166,6 +168,18 @@ struct SpikeView: View {
                 .presentationDetents([.medium, .large])
             }
         #endif
+    }
+
+    @ViewBuilder
+    private var statusOverlay: some View {
+        if let status = operationStatus {
+            Text(status)
+                .font(.caption)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                .padding(.bottom, 8)
+        }
     }
 
     // MARK: - Sidebar

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -208,6 +208,9 @@ struct SpikeView: View {
             overlaysSection
             projectionSection
             lightingSection
+            shadowSection
+            dofSection
+            taaSection
             statusSection
         }
         .navigationTitle("OCCTSwift Metal Demo")
@@ -973,6 +976,66 @@ struct SpikeView: View {
             VStack(alignment: .leading) {
                 Text("Matcap Blend: \(controller.lightingConfiguration.matcapBlend, specifier: "%.2f")")
                 Slider(value: $controller.lightingConfiguration.matcapBlend, in: 0...1)
+            }
+            VStack(alignment: .leading) {
+                Text("Exposure: \(controller.lightingConfiguration.exposure, specifier: "%.2f")")
+                Slider(value: $controller.lightingConfiguration.exposure, in: 0.5...3.0)
+            }
+            VStack(alignment: .leading) {
+                Text("White Point: \(controller.lightingConfiguration.whitePoint, specifier: "%.2f")")
+                Slider(value: $controller.lightingConfiguration.whitePoint, in: 0.5...2.0)
+            }
+        }
+    }
+
+    private var shadowSection: some View {
+        Section("Shadows") {
+            Toggle("Shadows", isOn: $controller.lightingConfiguration.shadowsEnabled)
+            if controller.lightingConfiguration.shadowsEnabled {
+                VStack(alignment: .leading) {
+                    Text("Shadow Intensity: \(controller.lightingConfiguration.shadowIntensity, specifier: "%.2f")")
+                    Slider(value: $controller.lightingConfiguration.shadowIntensity, in: 0...1)
+                }
+                VStack(alignment: .leading) {
+                    Text("PCSS Light Size: \(controller.lightingConfiguration.shadowLightSize, specifier: "%.3f")")
+                    Slider(value: $controller.lightingConfiguration.shadowLightSize, in: 0...0.1)
+                }
+                VStack(alignment: .leading) {
+                    Text("PCSS Search Radius: \(controller.lightingConfiguration.shadowSearchRadius, specifier: "%.3f")")
+                    Slider(value: $controller.lightingConfiguration.shadowSearchRadius, in: 0...0.05)
+                }
+            }
+        }
+    }
+
+    private var dofSection: some View {
+        Section("Depth of Field") {
+            Toggle("Enable DoF", isOn: $controller.enableDepthOfField)
+            if controller.enableDepthOfField {
+                VStack(alignment: .leading) {
+                    Text("Aperture: \(controller.dofAperture, specifier: "%.1f")")
+                    Slider(value: $controller.dofAperture, in: 0.5...16.0)
+                }
+                VStack(alignment: .leading) {
+                    Text("Focal Distance: \(controller.dofFocalDistance, specifier: "%.1f") (0 = auto)")
+                    Slider(value: $controller.dofFocalDistance, in: 0...100.0)
+                }
+                VStack(alignment: .leading) {
+                    Text("Max Blur: \(controller.dofMaxBlurRadius, specifier: "%.1f")")
+                    Slider(value: $controller.dofMaxBlurRadius, in: 1...20)
+                }
+            }
+        }
+    }
+
+    private var taaSection: some View {
+        Section("Anti-Aliasing") {
+            Toggle("Temporal AA (TAA)", isOn: $controller.enableTAA)
+            if controller.enableTAA {
+                VStack(alignment: .leading) {
+                    Text("Blend Factor: \(controller.taaBlendFactor, specifier: "%.2f")")
+                    Slider(value: $controller.taaBlendFactor, in: 0.5...0.98)
+                }
             }
         }
     }

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -549,6 +549,7 @@ struct SpikeView: View {
         case asymmetricChamfer, loftAdvanced, offsetByJoin, featureOps
         case pipeTransitions, faceFromSurface
         case sectionAndValidation, shapeRepair, multiFuse, splitFaceByWire
+        case projectionAndOffset, faceDivision, hollowAndAnalysis, obbAndBlend
     }
 
     private var occt8DemoSection: some View {
@@ -577,6 +578,10 @@ struct SpikeView: View {
             Button("Shape Repair") { loadOCCT8Demo(.shapeRepair) }
             Button("Multi-Fuse") { loadOCCT8Demo(.multiFuse) }
             Button("Split Face by Wire") { loadOCCT8Demo(.splitFaceByWire) }
+            Button("Projection & Offset") { loadOCCT8Demo(.projectionAndOffset) }
+            Button("Face Division") { loadOCCT8Demo(.faceDivision) }
+            Button("Hollow & Analysis") { loadOCCT8Demo(.hollowAndAnalysis) }
+            Button("OBB & Blend") { loadOCCT8Demo(.obbAndBlend) }
         }
     }
 
@@ -635,6 +640,14 @@ struct SpikeView: View {
             result = OCCT8Gallery.multiFuse()
         case .splitFaceByWire:
             result = OCCT8Gallery.splitFaceByWire()
+        case .projectionAndOffset:
+            result = OCCT8Gallery.projectionAndOffset()
+        case .faceDivision:
+            result = OCCT8Gallery.faceDivision()
+        case .hollowAndAnalysis:
+            result = OCCT8Gallery.hollowAndAnalysis()
+        case .obbAndBlend:
+            result = OCCT8Gallery.obbAndBlend()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -549,7 +549,8 @@ struct SpikeView: View {
         case asymmetricChamfer, loftAdvanced, offsetByJoin, featureOps
         case pipeTransitions, faceFromSurface
         case sectionAndValidation, shapeRepair, multiFuse, splitFaceByWire
-        case projectionAndOffset, faceDivision, hollowAndAnalysis, obbAndBlend
+        case projectionAndOffset, faceDivision, hollowAndAnalysis
+        case orientedBoundingBox, fuseAndBlend, variableOffset
     }
 
     private var occt8DemoSection: some View {
@@ -581,7 +582,9 @@ struct SpikeView: View {
             Button("Projection & Offset") { loadOCCT8Demo(.projectionAndOffset) }
             Button("Face Division") { loadOCCT8Demo(.faceDivision) }
             Button("Hollow & Analysis") { loadOCCT8Demo(.hollowAndAnalysis) }
-            Button("OBB & Blend") { loadOCCT8Demo(.obbAndBlend) }
+            Button("Oriented Bounding Box") { loadOCCT8Demo(.orientedBoundingBox) }
+            Button("Fuse & Blend") { loadOCCT8Demo(.fuseAndBlend) }
+            Button("Variable Offset") { loadOCCT8Demo(.variableOffset) }
         }
     }
 
@@ -646,8 +649,12 @@ struct SpikeView: View {
             result = OCCT8Gallery.faceDivision()
         case .hollowAndAnalysis:
             result = OCCT8Gallery.hollowAndAnalysis()
-        case .obbAndBlend:
-            result = OCCT8Gallery.obbAndBlend()
+        case .orientedBoundingBox:
+            result = OCCT8Gallery.orientedBoundingBox()
+        case .fuseAndBlend:
+            result = OCCT8Gallery.fuseAndBlend()
+        case .variableOffset:
+            result = OCCT8Gallery.variableOffset()
         }
 
         bodies = result.bodies

--- a/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -206,7 +206,12 @@ struct SpikeView: View {
     private var fileSection: some View {
         Section("File") {
             Button {
-                showFileImporter = true
+                // On iOS, dismiss the settings sheet first so the file
+                // importer can present without conflicting sheets.
+                showSettings = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    showFileImporter = true
+                }
             } label: {
                 Label("Open File (STEP/STL/OBJ)...", systemImage: "doc.badge.plus")
             }

--- a/Sources/OCCTSwiftViewport/Camera/CameraController.swift
+++ b/Sources/OCCTSwiftViewport/Camera/CameraController.swift
@@ -198,9 +198,12 @@ public final class CameraController: ObservableObject {
         // Horizontal rotation around Z axis
         theta -= deltaX * orbitSensitivity
 
-        // Vertical tilt with clamping
+        // Vertical tilt — unclamped for full 360° rotation
         phi -= deltaY * orbitSensitivity
-        phi = max(minPhi, min(maxPhi, phi))
+        // Wrap phi to [0, 2π) for clean cycling
+        let twoPi = Float.pi * 2
+        phi = phi.truncatingRemainder(dividingBy: twoPi)
+        if phi < 0 { phi += twoPi }
 
         // Convert spherical to quaternion
         updateRotationFromSpherical()
@@ -461,7 +464,9 @@ public final class CameraController: ObservableObject {
         // Extract theta and phi from rotation quaternion
         let forward = cameraState.rotation.act(SIMD3<Float>(0, 0, 1))
 
-        // Phi is angle from Z axis
+        // Phi is angle from Z axis (acos gives [0, pi])
+        // We accept the [0, pi] range here — continuous dragging maintains
+        // the full phi via incremental updates in orbitTurntable.
         phi = acos(simd_clamp(forward.z, -1, 1))
 
         // Theta is angle in XY plane

--- a/Sources/OCCTSwiftViewport/Camera/PivotStrategy.swift
+++ b/Sources/OCCTSwiftViewport/Camera/PivotStrategy.swift
@@ -85,7 +85,16 @@ public final class PivotStrategy {
         // Cast ray through view center
         let ray = Ray.throughViewCenter(cameraState: cameraState, aspectRatio: aspectRatio)
         let hit = SceneRaycast.cast(ray: ray, bodies: bodies, boundingBoxCache: bbCache)
-        let hitPoint = hit?.point ?? sceneCenter
+
+        // When zoomed in and the raycast misses geometry, keep the current pivot
+        // to avoid snapping back to scene center after the user panned away.
+        guard let hitPoint = hit?.point else {
+            // Zoomed out: safe to use scene center. Zoomed in: skip update.
+            if zoomRatio > config.zoomThreshold {
+                return sceneCenter
+            }
+            return nil
+        }
 
         // Fully zoomed in — use raycast hit
         if zoomRatio < config.zoomThreshold - halfBand {

--- a/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
@@ -119,6 +119,28 @@ public struct ViewportConfiguration: Sendable {
     /// Configuration for GPU-accelerated picking.
     public var pickingConfiguration: PickingConfiguration
 
+    // MARK: - Depth of Field
+
+    /// Whether post-process depth of field is enabled.
+    public var enableDepthOfField: Bool
+
+    /// DoF aperture (smaller = shallower depth of field).
+    public var dofAperture: Float
+
+    /// DoF focal distance (0 = autofocus on selection or scene center).
+    public var dofFocalDistance: Float
+
+    /// Maximum blur radius in pixels for DoF.
+    public var dofMaxBlurRadius: Float
+
+    // MARK: - Temporal Anti-Aliasing
+
+    /// Whether temporal anti-aliasing is enabled.
+    public var enableTAA: Bool
+
+    /// TAA history blend factor (0 = no history, 1 = full history).
+    public var taaBlendFactor: Float
+
     // MARK: - Dynamic Pivot
 
     /// Configuration for automatic orbit-pivot adjustment.
@@ -153,6 +175,12 @@ public struct ViewportConfiguration: Sendable {
         silhouetteThickness: Float = 1.0,
         silhouetteIntensity: Float = 0.7,
         pickingConfiguration: PickingConfiguration = .init(),
+        enableDepthOfField: Bool = false,
+        dofAperture: Float = 2.8,
+        dofFocalDistance: Float = 0,
+        dofMaxBlurRadius: Float = 8.0,
+        enableTAA: Bool = false,
+        taaBlendFactor: Float = 0.9,
         dynamicPivotConfiguration: DynamicPivotConfiguration = .default
     ) {
         self.initialCameraState = initialCameraState
@@ -180,6 +208,12 @@ public struct ViewportConfiguration: Sendable {
         self.silhouetteThickness = silhouetteThickness
         self.silhouetteIntensity = silhouetteIntensity
         self.pickingConfiguration = pickingConfiguration
+        self.enableDepthOfField = enableDepthOfField
+        self.dofAperture = dofAperture
+        self.dofFocalDistance = dofFocalDistance
+        self.dofMaxBlurRadius = dofMaxBlurRadius
+        self.enableTAA = enableTAA
+        self.taaBlendFactor = taaBlendFactor
         self.dynamicPivotConfiguration = dynamicPivotConfiguration
     }
 

--- a/Sources/OCCTSwiftViewport/Display/LightingConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Display/LightingConfiguration.swift
@@ -130,24 +130,27 @@ public struct LightingConfiguration: Sendable {
     /// - Back light for edge definition
     public static let threePoint = LightingConfiguration(
         keyLight: LightSettings(
-            direction: simd_normalize(SIMD3<Float>(-0.5, -0.3, -0.8)),
+            direction: simd_normalize(SIMD3<Float>(-0.5, -0.6, -0.6)),  // Higher elevation (30-45°)
             intensity: 1.0,
-            color: SIMD3<Float>(1.0, 0.98, 0.95)  // Slightly warm
+            color: SIMD3<Float>(1.0, 0.96, 0.90)  // Warmer key
         ),
         fillLight: LightSettings(
-            direction: simd_normalize(SIMD3<Float>(0.6, 0.1, -0.5)),
+            direction: simd_normalize(SIMD3<Float>(0.6, -0.1, -0.5)),  // Slight downward angle
             intensity: 0.4,
-            color: SIMD3<Float>(0.95, 0.97, 1.0)  // Slightly cool
+            color: SIMD3<Float>(0.85, 0.92, 1.0)  // Cooler fill for contrast
         ),
         backLight: LightSettings(
-            direction: simd_normalize(SIMD3<Float>(0.0, 0.5, 0.8)),
-            intensity: 0.3,
-            color: SIMD3<Float>(1.0, 1.0, 1.0)
+            direction: simd_normalize(SIMD3<Float>(0.2, 0.8, 0.5)),  // From below-behind (kicker)
+            intensity: 0.35,
+            color: SIMD3<Float>(0.95, 0.97, 1.0)
         ),
         ambientIntensity: 0.25,
+        shadowIntensity: 0.2,
         specularPower: 64.0,
         specularIntensity: 0.5,
-        fresnelIntensity: 0.3
+        fresnelIntensity: 0.35,
+        ssaoRadius: 0.8,
+        ssaoIntensity: 0.8
     )
 
     /// Soft studio lighting.

--- a/Sources/OCCTSwiftViewport/Display/LightingConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Display/LightingConfiguration.swift
@@ -74,6 +74,24 @@ public struct LightingConfiguration: Sendable {
     /// SSAO darkening intensity (0 = none, 1 = maximum).
     public var ssaoIntensity: Float
 
+    /// Tone mapping exposure multiplier (default 1.1).
+    public var exposure: Float
+
+    /// White point for tone mapping normalization (default 1.0).
+    public var whitePoint: Float
+
+    /// PCSS light source size (larger = softer shadow penumbras).
+    public var shadowLightSize: Float
+
+    /// PCSS blocker search radius in light-space UV.
+    public var shadowSearchRadius: Float
+
+    /// Environment map HDR data (equirectangular), or nil for procedural sky.
+    public var environmentMapData: Data?
+
+    /// Environment map intensity multiplier.
+    public var environmentIntensity: Float
+
     // MARK: - Initialization
 
     public init(
@@ -96,7 +114,13 @@ public struct LightingConfiguration: Sendable {
         ambientGroundColor: SIMD3<Float> = SIMD3<Float>(0.3, 0.25, 0.2),
         enableSSAO: Bool = true,
         ssaoRadius: Float = 0.5,
-        ssaoIntensity: Float = 0.6
+        ssaoIntensity: Float = 0.6,
+        exposure: Float = 1.1,
+        whitePoint: Float = 1.0,
+        shadowLightSize: Float = 0.02,
+        shadowSearchRadius: Float = 0.01,
+        environmentMapData: Data? = nil,
+        environmentIntensity: Float = 1.0
     ) {
         self.keyLight = keyLight
         self.fillLight = fillLight
@@ -118,6 +142,12 @@ public struct LightingConfiguration: Sendable {
         self.enableSSAO = enableSSAO
         self.ssaoRadius = ssaoRadius
         self.ssaoIntensity = ssaoIntensity
+        self.exposure = exposure
+        self.whitePoint = whitePoint
+        self.shadowLightSize = shadowLightSize
+        self.shadowSearchRadius = shadowSearchRadius
+        self.environmentMapData = environmentMapData
+        self.environmentIntensity = environmentIntensity
     }
 
     // MARK: - Presets
@@ -221,15 +251,26 @@ public struct LightingConfiguration: Sendable {
         ambientIntensity: 0.6,
         shadowsEnabled: false,
         specularIntensity: 0.0,
-        fresnelIntensity: 0.0
+        fresnelIntensity: 0.0,
+        exposure: 0.9
     )
+}
+
+// MARK: - Light Type
+
+/// Type of light source.
+public enum LightType: Sendable, Equatable {
+    /// Directional light (sun-like, no falloff).
+    case directional
+    /// Point light with smooth radius falloff.
+    case point(radius: Float)
 }
 
 // MARK: - Light Settings
 
 /// Settings for a single light source.
 public struct LightSettings: Sendable {
-    /// Direction the light is pointing (normalized).
+    /// Direction the light is pointing (normalized). For point lights, ignored.
     public var direction: SIMD3<Float>
 
     /// Light intensity (0-2 typical range).
@@ -241,15 +282,25 @@ public struct LightSettings: Sendable {
     /// Whether this light is enabled.
     public var isEnabled: Bool
 
+    /// Type of light source.
+    public var lightType: LightType
+
+    /// World-space position (used for point lights).
+    public var position: SIMD3<Float>
+
     public init(
         direction: SIMD3<Float>,
         intensity: Float = 1.0,
         color: SIMD3<Float> = SIMD3<Float>(1, 1, 1),
-        isEnabled: Bool = true
+        isEnabled: Bool = true,
+        lightType: LightType = .directional,
+        position: SIMD3<Float> = .zero
     ) {
         self.direction = direction
         self.intensity = intensity
         self.color = color
         self.isEnabled = isEnabled
+        self.lightType = lightType
+        self.position = position
     }
 }

--- a/Sources/OCCTSwiftViewport/Renderer/EnvironmentMapManager.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/EnvironmentMapManager.swift
@@ -1,0 +1,248 @@
+// EnvironmentMapManager.swift
+// ViewportKit
+//
+// Manages HDR environment maps for image-based lighting (IBL).
+// Loads equirectangular HDR → cube map, generates prefiltered specular
+// mip chain, diffuse irradiance map, and BRDF LUT.
+
+@preconcurrency import Metal
+
+@MainActor
+final class EnvironmentMapManager {
+
+    private let device: MTLDevice
+    private let equirectToCubePipeline: MTLComputePipelineState?
+    private let prefilterPipeline: MTLComputePipelineState?
+    private let irradiancePipeline: MTLComputePipelineState?
+    private let brdfPipeline: MTLComputePipelineState?
+
+    private(set) var cubeMap: MTLTexture?
+    private(set) var prefilteredSpecularMap: MTLTexture?
+    private(set) var irradianceMap: MTLTexture?
+    private(set) var brdfLUT: MTLTexture?
+
+    var hasEnvironmentMap: Bool { cubeMap != nil }
+
+    init(device: MTLDevice, library: MTLLibrary) {
+        self.device = device
+
+        self.equirectToCubePipeline = Self.makeComputePipeline(device: device, library: library, name: "equirect_to_cubemap")
+        self.prefilterPipeline = Self.makeComputePipeline(device: device, library: library, name: "prefilter_environment")
+        self.irradiancePipeline = Self.makeComputePipeline(device: device, library: library, name: "irradiance_convolution")
+        self.brdfPipeline = Self.makeComputePipeline(device: device, library: library, name: "brdf_integration")
+
+        // Pre-generate BRDF LUT (resolution-independent, only needs to be done once)
+        generateBRDFLUT(commandQueue: device.makeCommandQueue()!)
+    }
+
+    private static func makeComputePipeline(device: MTLDevice, library: MTLLibrary, name: String) -> MTLComputePipelineState? {
+        guard let function = library.makeFunction(name: name) else { return nil }
+        return try? device.makeComputePipelineState(function: function)
+    }
+
+    func clear() {
+        cubeMap = nil
+        prefilteredSpecularMap = nil
+        irradianceMap = nil
+    }
+
+    /// Loads equirectangular HDR data and generates all IBL textures.
+    func loadEquirectangular(data: Data, commandQueue: MTLCommandQueue) {
+        // Parse as raw RGBA float data or simple HDR
+        // For simplicity, expect RGBA32Float raw data with dimensions encoded in first 8 bytes
+        guard data.count > 8 else { return }
+
+        let width = data.withUnsafeBytes { $0.load(fromByteOffset: 0, as: Int32.self) }
+        let height = data.withUnsafeBytes { $0.load(fromByteOffset: 4, as: Int32.self) }
+        let pixelDataOffset = 8
+        let expectedSize = pixelDataOffset + Int(width) * Int(height) * 16 // 4 floats * 4 bytes
+
+        guard data.count >= expectedSize, width > 0, height > 0 else { return }
+
+        // Create equirectangular texture
+        let eqDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba32Float,
+            width: Int(width),
+            height: Int(height),
+            mipmapped: false
+        )
+        eqDesc.usage = [.shaderRead]
+        guard let eqTexture = device.makeTexture(descriptor: eqDesc) else { return }
+
+        data.withUnsafeBytes { rawBuffer in
+            let pixelPtr = rawBuffer.baseAddress! + pixelDataOffset
+            eqTexture.replace(
+                region: MTLRegionMake2D(0, 0, Int(width), Int(height)),
+                mipmapLevel: 0,
+                withBytes: pixelPtr,
+                bytesPerRow: Int(width) * 16
+            )
+        }
+
+        // Generate cubemap from equirectangular
+        let cubeSize = 256
+        generateCubeMap(from: eqTexture, size: cubeSize, commandQueue: commandQueue)
+    }
+
+    private func generateCubeMap(from equirect: MTLTexture, size: Int, commandQueue: MTLCommandQueue) {
+        guard let pipeline = equirectToCubePipeline else { return }
+
+        // Create cube map
+        let cubeDesc = MTLTextureDescriptor.textureCubeDescriptor(
+            pixelFormat: .rgba16Float,
+            size: size,
+            mipmapped: true
+        )
+        cubeDesc.usage = [.shaderRead, .shaderWrite]
+        cubeDesc.storageMode = .private
+        guard let cube = device.makeTexture(descriptor: cubeDesc) else { return }
+        self.cubeMap = cube
+
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
+
+        encoder.setComputePipelineState(pipeline)
+        encoder.setTexture(equirect, index: 0)
+        encoder.setTexture(cube, index: 1)
+
+        let threadsPerGroup = MTLSize(width: 16, height: 16, depth: 1)
+        let threadgroups = MTLSize(
+            width: (size + 15) / 16,
+            height: (size + 15) / 16,
+            depth: 6
+        )
+        encoder.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+        encoder.endEncoding()
+
+        // Generate mipmaps
+        if let blit = commandBuffer.makeBlitCommandEncoder() {
+            blit.generateMipmaps(for: cube)
+            blit.endEncoding()
+        }
+
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        // Generate prefiltered specular and irradiance
+        generatePrefilteredSpecular(from: cube, commandQueue: commandQueue)
+        generateIrradiance(from: cube, commandQueue: commandQueue)
+    }
+
+    private func generatePrefilteredSpecular(from cube: MTLTexture, commandQueue: MTLCommandQueue) {
+        guard let pipeline = prefilterPipeline else { return }
+
+        let size = 128
+        let mipLevels = 8
+
+        let desc = MTLTextureDescriptor.textureCubeDescriptor(
+            pixelFormat: .rgba16Float,
+            size: size,
+            mipmapped: true
+        )
+        desc.usage = [.shaderRead, .shaderWrite]
+        desc.storageMode = .private
+        desc.mipmapLevelCount = mipLevels
+        guard let prefiltered = device.makeTexture(descriptor: desc) else { return }
+        self.prefilteredSpecularMap = prefiltered
+
+        for mip in 0..<mipLevels {
+            let mipSize = max(size >> mip, 1)
+            let roughness = Float(mip) / Float(mipLevels - 1)
+
+            // Create a view for this mip level
+            guard let mipView = prefiltered.makeTextureView(
+                pixelFormat: .rgba16Float,
+                textureType: .typeCube,
+                levels: mip..<(mip + 1),
+                slices: 0..<6
+            ) else { continue }
+
+            guard let commandBuffer = commandQueue.makeCommandBuffer(),
+                  let encoder = commandBuffer.makeComputeCommandEncoder() else { continue }
+
+            encoder.setComputePipelineState(pipeline)
+            encoder.setTexture(cube, index: 0)
+            encoder.setTexture(mipView, index: 1)
+            var roughnessValue = roughness
+            encoder.setBytes(&roughnessValue, length: MemoryLayout<Float>.size, index: 0)
+
+            let threadsPerGroup = MTLSize(width: 16, height: 16, depth: 1)
+            let threadgroups = MTLSize(
+                width: max((mipSize + 15) / 16, 1),
+                height: max((mipSize + 15) / 16, 1),
+                depth: 6
+            )
+            encoder.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+            encoder.endEncoding()
+            commandBuffer.commit()
+            commandBuffer.waitUntilCompleted()
+        }
+    }
+
+    private func generateIrradiance(from cube: MTLTexture, commandQueue: MTLCommandQueue) {
+        guard let pipeline = irradiancePipeline else { return }
+
+        let size = 32
+
+        let desc = MTLTextureDescriptor.textureCubeDescriptor(
+            pixelFormat: .rgba16Float,
+            size: size,
+            mipmapped: false
+        )
+        desc.usage = [.shaderRead, .shaderWrite]
+        desc.storageMode = .private
+        guard let irr = device.makeTexture(descriptor: desc) else { return }
+        self.irradianceMap = irr
+
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
+
+        encoder.setComputePipelineState(pipeline)
+        encoder.setTexture(cube, index: 0)
+        encoder.setTexture(irr, index: 1)
+
+        let threadsPerGroup = MTLSize(width: 16, height: 16, depth: 1)
+        let threadgroups = MTLSize(
+            width: (size + 15) / 16,
+            height: (size + 15) / 16,
+            depth: 6
+        )
+        encoder.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+    }
+
+    private func generateBRDFLUT(commandQueue: MTLCommandQueue) {
+        guard let pipeline = brdfPipeline else { return }
+
+        let size = 256
+        let desc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rg16Float,
+            width: size,
+            height: size,
+            mipmapped: false
+        )
+        desc.usage = [.shaderRead, .shaderWrite]
+        desc.storageMode = .private
+        guard let lut = device.makeTexture(descriptor: desc) else { return }
+        self.brdfLUT = lut
+
+        guard let commandBuffer = commandQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeComputeCommandEncoder() else { return }
+
+        encoder.setComputePipelineState(pipeline)
+        encoder.setTexture(lut, index: 0)
+
+        let threadsPerGroup = MTLSize(width: 16, height: 16, depth: 1)
+        let threadgroups = MTLSize(
+            width: (size + 15) / 16,
+            height: (size + 15) / 16,
+            depth: 1
+        )
+        encoder.dispatchThreadgroups(threadgroups, threadsPerThreadgroup: threadsPerGroup)
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+    }
+}

--- a/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
+++ b/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
@@ -11,6 +11,8 @@ using namespace metal;
 struct LightData {
     float4 directionAndIntensity;  // xyz = normalized direction, w = intensity
     float4 colorAndEnabled;        // rgb = color, a = 1.0 if enabled, 0.0 if not
+    float4 typeAndParams;          // x = type (0=directional, 1=point), y = radius, z/w = unused
+    float4 positionAndPad;         // xyz = world position (point lights), w = unused
 };
 
 struct Uniforms {
@@ -24,7 +26,9 @@ struct Uniforms {
     float4   materialParams;           // x = fresnelPower, y = fresnelIntensity,
                                        // z = matcapBlend, w = farPlane
     float4x4 lightViewProjectionMatrix; // for shadow mapping
-    float4   shadowParams;             // x = bias, y = intensity, z = enabled, w = unused
+    float4   shadowParams;             // x = bias, y = intensity, z = enabled, w = edgeIntensity
+    float4   shadowParams2;            // x = lightSize, y = searchRadius, z/w = unused (PCSS)
+    float4   iblParams;                // x = intensity, y/z = unused, w = hasEnvMap (>0.5)
     float4   clipPlanes[4];            // xyz = normal, w = distance (dot(N,P)+w < 0 → clip)
     uint     clipPlaneCount;           // number of active clip planes (0–4)
     float3   _clipPad;                 // padding to 16-byte alignment
@@ -138,8 +142,21 @@ vertex ShadedVertexOut shaded_vertex(
     return out;
 }
 
-// PCF shadow sampling with 4 taps
-inline float sampleShadow(float4 lightSpacePos, depth2d<float> shadowMap, float bias) {
+// Poisson disk samples for PCSS (16 points)
+constant float2 poissonDisk[16] = {
+    float2(-0.94201624, -0.39906216), float2( 0.94558609, -0.76890725),
+    float2(-0.09418410, -0.92938870), float2( 0.34495938,  0.29387760),
+    float2(-0.91588581,  0.45771432), float2(-0.81544232, -0.87912464),
+    float2(-0.38277543,  0.27676845), float2( 0.97484398,  0.75648379),
+    float2( 0.44323325, -0.97511554), float2( 0.53742981, -0.47373420),
+    float2(-0.26496911, -0.41893023), float2( 0.79197514,  0.19090188),
+    float2(-0.24188840,  0.99706507), float2(-0.81409955,  0.91437590),
+    float2( 0.19984126,  0.78641367), float2( 0.14383161, -0.14100790)
+};
+
+// PCSS shadow sampling: percentage-closer soft shadows
+inline float sampleShadow(float4 lightSpacePos, depth2d<float> shadowMap,
+                           float bias, float lightSize, float searchRadius) {
     // Perspective divide
     float3 projCoords = lightSpacePos.xyz / lightSpacePos.w;
     // Transform from [-1,1] to [0,1] UV space
@@ -153,19 +170,55 @@ inline float sampleShadow(float4 lightSpacePos, depth2d<float> shadowMap, float 
     }
 
     constexpr sampler shadowSampler(filter::linear, address::clamp_to_edge, compare_func::less);
-
-    // 4-tap PCF
     float2 texelSize = 1.0 / float2(shadowMap.get_width(), shadowMap.get_height());
+
+    // When lightSize is negligible, fall back to simple 4-tap PCF
+    if (lightSize < 0.001) {
+        float shadow = 0.0;
+        const float2 offsets[4] = {
+            float2(-0.5, -0.5), float2( 0.5, -0.5),
+            float2(-0.5,  0.5), float2( 0.5,  0.5)
+        };
+        for (int i = 0; i < 4; i++) {
+            float2 uv = shadowUV + offsets[i] * texelSize;
+            shadow += shadowMap.sample_compare(shadowSampler, uv, currentDepth - bias);
+        }
+        return shadow / 4.0;
+    }
+
+    // Step 1: Blocker search — find average blocker depth
+    constexpr sampler depthSampler(filter::nearest, address::clamp_to_edge);
+    float blockerSum = 0.0;
+    float blockerCount = 0.0;
+    float sr = max(searchRadius, lightSize);
+
+    for (int i = 0; i < 16; i++) {
+        float2 uv = shadowUV + poissonDisk[i] * sr;
+        float sampleDepth = shadowMap.sample(depthSampler, uv);
+        if (sampleDepth < currentDepth - bias) {
+            blockerSum += sampleDepth;
+            blockerCount += 1.0;
+        }
+    }
+
+    // No blockers found → fully lit
+    if (blockerCount < 1.0) {
+        return 1.0;
+    }
+
+    float avgBlockerDepth = blockerSum / blockerCount;
+
+    // Step 2: Penumbra width estimation
+    float penumbraWidth = lightSize * (currentDepth - avgBlockerDepth) / max(avgBlockerDepth, 0.0001);
+    penumbraWidth = clamp(penumbraWidth, texelSize.x, lightSize * 4.0);
+
+    // Step 3: PCF with variable radius
     float shadow = 0.0;
-    const float2 offsets[4] = {
-        float2(-0.5, -0.5), float2( 0.5, -0.5),
-        float2(-0.5,  0.5), float2( 0.5,  0.5)
-    };
-    for (int i = 0; i < 4; i++) {
-        float2 uv = shadowUV + offsets[i] * texelSize;
+    for (int i = 0; i < 16; i++) {
+        float2 uv = shadowUV + poissonDisk[i] * penumbraWidth;
         shadow += shadowMap.sample_compare(shadowSampler, uv, currentDepth - bias);
     }
-    return shadow / 4.0;
+    return shadow / 16.0;
 }
 
 fragment ShadedFragmentOut shaded_fragment(
@@ -173,7 +226,10 @@ fragment ShadedFragmentOut shaded_fragment(
     constant Uniforms &uniforms [[buffer(1)]],
     constant BodyUniforms &bodyUniforms [[buffer(2)]],
     texture2d<float> matcapTexture [[texture(0)]],
-    depth2d<float> shadowMap [[texture(1)]]
+    depth2d<float> shadowMap [[texture(1)]],
+    texturecube<float> iblSpecular [[texture(2)]],
+    texturecube<float> iblDiffuse [[texture(3)]],
+    texture2d<float> brdfLUT [[texture(4)]]
 ) {
     // Clip plane discard
     for (uint cp = 0; cp < uniforms.clipPlaneCount; cp++) {
@@ -205,9 +261,27 @@ fragment ShadedFragmentOut shaded_fragment(
         float enabled = uniforms.lights[i].colorAndEnabled.a;
         if (enabled < 0.5) continue;
 
-        float3 L = normalize(-uniforms.lights[i].directionAndIntensity.xyz);
+        float lightTypeVal = uniforms.lights[i].typeAndParams.x;
         float intensity = uniforms.lights[i].directionAndIntensity.w;
         float3 lightColor = uniforms.lights[i].colorAndEnabled.rgb;
+        float3 L;
+
+        if (lightTypeVal > 0.5) {
+            // Point light
+            float3 lightPos = uniforms.lights[i].positionAndPad.xyz;
+            float3 toLight = lightPos - in.worldPosition;
+            float dist = length(toLight);
+            L = toLight / max(dist, 0.0001);
+            // Inverse-square falloff with windowed radius
+            float lightRadius = max(uniforms.lights[i].typeAndParams.y, 0.01);
+            float windowed = saturate(1.0 - pow(dist / lightRadius, 4.0));
+            float attenuation = (windowed * windowed) / (dist * dist + 0.0001);
+            intensity *= attenuation;
+        } else {
+            // Directional light
+            L = normalize(-uniforms.lights[i].directionAndIntensity.xyz);
+        }
+
         float3 H = normalize(L + V);
 
         float NdotL = max(dot(N, L), 0.0);
@@ -230,10 +304,11 @@ fragment ShadedFragmentOut shaded_fragment(
         Lo += (diffuse + specular) * lightColor * intensity * NdotL;
     }
 
-    // Shadow mapping: darken key light contribution
+    // Shadow mapping: darken key light contribution (PCSS soft shadows)
     if (uniforms.shadowParams.z > 0.5) {
         float4 lightSpacePos = uniforms.lightViewProjectionMatrix * uniforms.modelMatrix * float4(in.worldPosition, 1.0);
-        float shadowFactor = sampleShadow(lightSpacePos, shadowMap, uniforms.shadowParams.x);
+        float shadowFactor = sampleShadow(lightSpacePos, shadowMap, uniforms.shadowParams.x,
+                                           uniforms.shadowParams2.x, uniforms.shadowParams2.y);
         float shadowDarkness = uniforms.shadowParams.y;
         Lo *= mix(1.0 - shadowDarkness, 1.0, shadowFactor);
     }
@@ -249,12 +324,30 @@ fragment ShadedFragmentOut shaded_fragment(
     float3 ambientZ = mix(float3(0.25, 0.25, 0.27), float3(0.32, 0.32, 0.30), N.z * 0.5 + 0.5);
     float3 ambient = ((ambientY * 0.6) + (ambientX * 0.2) + (ambientZ * 0.2)) * bodyColor * (1.0 - metallic * 0.5);
 
-    // Environment reflection approximation
+    // Environment reflection: IBL when available, procedural fallback otherwise
     float3 R = reflect(-V, N);
-    float3 envColor = sampleEnvironment(R);
-    float envFresnel = pow(1.0 - NdotV, 5.0);
-    float envStrength = mix(0.04, 1.0, metallic) * mix(0.3, 1.0, envFresnel) * (1.0 - roughness * 0.7);
-    float3 envContribution = envColor * mix(float3(0.04), bodyColor, metallic) * envStrength;
+    float3 envContribution;
+    if (uniforms.iblParams.w > 0.5) {
+        // Image-based lighting with split-sum approximation
+        constexpr sampler iblSampler(filter::linear, mip_filter::linear, address::repeat);
+        constexpr sampler brdfSampler(filter::linear, address::clamp_to_edge);
+        float iblIntensity = uniforms.iblParams.x;
+        float mipLevel = roughness * 7.0; // assume 8 mip levels
+        float3 prefilteredColor = iblSpecular.sample(iblSampler, R, level(mipLevel)).rgb;
+        float3 irradiance = iblDiffuse.sample(iblSampler, N).rgb;
+        float2 brdf = brdfLUT.sample(brdfSampler, float2(NdotV, roughness)).rg;
+        float3 F_ibl = fresnelSchlick(NdotV, F0);
+        float3 specularIBL = prefilteredColor * (F_ibl * brdf.x + brdf.y);
+        float3 kD_ibl = (1.0 - F_ibl) * (1.0 - metallic);
+        float3 diffuseIBL = irradiance * bodyColor;
+        envContribution = (kD_ibl * diffuseIBL + specularIBL) * iblIntensity;
+    } else {
+        // Procedural environment fallback
+        float3 envColor = sampleEnvironment(R);
+        float envFresnel = pow(1.0 - NdotV, 5.0);
+        float envStrength = mix(0.04, 1.0, metallic) * mix(0.3, 1.0, envFresnel) * (1.0 - roughness * 0.7);
+        envContribution = envColor * mix(float3(0.04), bodyColor, metallic) * envStrength;
+    }
 
     // Fresnel rim (reduced for metallic surfaces)
     float fresnel = fresnelIntensity * (1.0 - metallic * 0.5) * pow(1.0 - NdotV, fresnelPower);
@@ -577,6 +670,12 @@ struct SSAOParams {
     float  farPlane;
     float  silhouetteThickness; // edge detection spread
     float  silhouetteIntensity; // edge darkness
+    float  exposure;            // tone mapping exposure (default 1.1)
+    float  whitePoint;          // tone mapping white point (default 1.0)
+    float  dofAperture;         // depth of field aperture
+    float  dofFocalDistance;    // depth of field focal distance (0 = auto)
+    float  dofMaxBlurRadius;    // maximum CoC blur radius in pixels
+    float  dofEnabled;          // 1.0 if DoF active, 0.0 otherwise
 };
 
 struct FullscreenVertexOut {
@@ -718,12 +817,47 @@ fragment float4 ssao_fragment(
     float3 finalColor = sceneColor.rgb * result_ao * depthContrast;
     finalColor = mix(finalColor, float3(0.1, 0.1, 0.12), result_edge);
 
+    // --- Depth of Field (CoC-based disk blur) ---
+    if (params.dofEnabled > 0.5) {
+        float focalDist = params.dofFocalDistance;
+        float aperture = max(params.dofAperture, 0.1);
+        float maxBlur = params.dofMaxBlurRadius;
+
+        // Circle of confusion diameter
+        float coc = abs(linearDepth - focalDist) / aperture;
+        coc = clamp(coc * maxBlur, 0.0, maxBlur);
+
+        if (coc > 0.5) {
+            // 8-tap disk blur
+            float3 blurColor = float3(0.0);
+            float totalWeight = 0.0;
+            const float2 dofOffsets[8] = {
+                float2( 1.0,  0.0), float2(-1.0,  0.0),
+                float2( 0.0,  1.0), float2( 0.0, -1.0),
+                float2( 0.707,  0.707), float2(-0.707,  0.707),
+                float2( 0.707, -0.707), float2(-0.707, -0.707)
+            };
+            for (int i = 0; i < 8; i++) {
+                float2 sampleUV = in.texCoord + dofOffsets[i] * params.texelSize * coc;
+                float3 sampleColor = colorTexture.sample(texSampler, sampleUV).rgb;
+                // Apply AO and depth contrast to sample too
+                blurColor += sampleColor * result_ao * depthContrast;
+                totalWeight += 1.0;
+            }
+            blurColor /= totalWeight;
+            // Blend between sharp and blurred based on CoC
+            float blendFactor = smoothstep(0.5, 2.0, coc);
+            finalColor = mix(finalColor, blurColor, blendFactor);
+        }
+    }
+
     // --- ACES Filmic Tone Mapping ---
     // Compresses dynamic range so highlights don't clip and shadows retain detail.
     // Uses the Narkowicz ACES approximation (industry standard).
     {
-        float exposure = 1.1;
-        float3 x = finalColor * exposure;
+        float exposure = params.exposure;
+        float wp = max(params.whitePoint, 0.01);
+        float3 x = finalColor * exposure / wp;
         float a = 2.51;
         float b = 0.03;
         float c = 2.43;
@@ -733,4 +867,250 @@ fragment float4 ssao_fragment(
     }
 
     return float4(finalColor, sceneColor.a);
+}
+
+// MARK: - Temporal Anti-Aliasing Resolve
+
+struct TAAParams {
+    float  blendFactor;   // history weight (0.9 typical)
+    float  _pad0;
+    float2 jitterOffset;  // sub-pixel jitter applied this frame
+    float2 texelSize;
+};
+
+fragment float4 taa_resolve_fragment(
+    FullscreenVertexOut in [[stage_in]],
+    texture2d<float> currentTexture [[texture(0)]],
+    texture2d<float> historyTexture [[texture(1)]],
+    constant TAAParams &params [[buffer(0)]]
+) {
+    constexpr sampler texSampler(filter::linear, address::clamp_to_edge);
+    constexpr sampler pointSampler(filter::nearest, address::clamp_to_edge);
+
+    float4 current = currentTexture.sample(pointSampler, in.texCoord);
+
+    // 3x3 neighborhood clamp to reduce ghosting
+    float3 nearMin = current.rgb;
+    float3 nearMax = current.rgb;
+    const float2 offsets[8] = {
+        float2(-1, -1), float2(0, -1), float2(1, -1),
+        float2(-1,  0),                float2(1,  0),
+        float2(-1,  1), float2(0,  1), float2(1,  1)
+    };
+    for (int i = 0; i < 8; i++) {
+        float3 s = currentTexture.sample(pointSampler,
+            in.texCoord + offsets[i] * params.texelSize).rgb;
+        nearMin = min(nearMin, s);
+        nearMax = max(nearMax, s);
+    }
+
+    // Sample history (unjitter by subtracting this frame's jitter)
+    float2 historyUV = in.texCoord - params.jitterOffset * params.texelSize;
+    float4 history = historyTexture.sample(texSampler, historyUV);
+
+    // Clamp history to neighborhood AABB
+    history.rgb = clamp(history.rgb, nearMin, nearMax);
+
+    // Blend
+    float4 result = mix(current, history, params.blendFactor);
+    return result;
+}
+
+// MARK: - IBL Compute Kernels
+
+// Equirectangular → Cubemap conversion
+kernel void equirect_to_cubemap(
+    texture2d<float, access::sample> equirect [[texture(0)]],
+    texturecube<float, access::write> cubeMap [[texture(1)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    uint face = gid.z;
+    uint size = cubeMap.get_width();
+    if (gid.x >= size || gid.y >= size) return;
+
+    float2 uv = (float2(gid.xy) + 0.5) / float(size) * 2.0 - 1.0;
+    float3 dir;
+    switch (face) {
+        case 0: dir = float3( 1.0, -uv.y, -uv.x); break; // +X
+        case 1: dir = float3(-1.0, -uv.y,  uv.x); break; // -X
+        case 2: dir = float3( uv.x,  1.0,  uv.y); break; // +Y
+        case 3: dir = float3( uv.x, -1.0, -uv.y); break; // -Y
+        case 4: dir = float3( uv.x, -uv.y,  1.0); break; // +Z
+        case 5: dir = float3(-uv.x, -uv.y, -1.0); break; // -Z
+        default: dir = float3(0); break;
+    }
+    dir = normalize(dir);
+
+    // Convert direction to equirectangular UV
+    float phi = atan2(dir.z, dir.x);
+    float theta = asin(clamp(dir.y, -1.0, 1.0));
+    float2 eqUV = float2(phi / (2.0 * M_PI_F) + 0.5, theta / M_PI_F + 0.5);
+
+    constexpr sampler s(filter::linear, address::repeat);
+    float4 color = equirect.sample(s, eqUV);
+    cubeMap.write(color, gid.xy, face);
+}
+
+// Prefilter environment for specular IBL (roughness-based mip levels)
+kernel void prefilter_environment(
+    texturecube<float, access::sample> envMap [[texture(0)]],
+    texturecube<float, access::write> filtered [[texture(1)]],
+    constant float &roughness [[buffer(0)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    uint face = gid.z;
+    uint size = filtered.get_width();
+    if (gid.x >= size || gid.y >= size) return;
+
+    float2 uv = (float2(gid.xy) + 0.5) / float(size) * 2.0 - 1.0;
+    float3 N;
+    switch (face) {
+        case 0: N = normalize(float3( 1.0, -uv.y, -uv.x)); break;
+        case 1: N = normalize(float3(-1.0, -uv.y,  uv.x)); break;
+        case 2: N = normalize(float3( uv.x,  1.0,  uv.y)); break;
+        case 3: N = normalize(float3( uv.x, -1.0, -uv.y)); break;
+        case 4: N = normalize(float3( uv.x, -uv.y,  1.0)); break;
+        case 5: N = normalize(float3(-uv.x, -uv.y, -1.0)); break;
+        default: N = float3(0); break;
+    }
+    float3 R = N;
+    float3 V = R;
+
+    constexpr sampler s(filter::linear, mip_filter::linear, address::repeat);
+    float totalWeight = 0.0;
+    float3 prefilteredColor = float3(0.0);
+    const uint SAMPLE_COUNT = 64u;
+
+    for (uint i = 0u; i < SAMPLE_COUNT; i++) {
+        // Hammersley sequence
+        float fi = float(i);
+        uint bits = i;
+        bits = (bits << 16u) | (bits >> 16u);
+        bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+        bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+        bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+        bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+        float2 Xi = float2(fi / float(SAMPLE_COUNT), float(bits) * 2.3283064365386963e-10);
+
+        // GGX importance sampling
+        float a = roughness * roughness;
+        float phi = 2.0 * M_PI_F * Xi.x;
+        float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+        float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+        float3 H = float3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+
+        // Tangent space to world
+        float3 up = abs(N.z) < 0.999 ? float3(0, 0, 1) : float3(1, 0, 0);
+        float3 T = normalize(cross(up, N));
+        float3 B = cross(N, T);
+        float3 sampleDir = T * H.x + B * H.y + N * H.z;
+
+        float NdotL = max(dot(N, sampleDir), 0.0);
+        if (NdotL > 0.0) {
+            prefilteredColor += envMap.sample(s, sampleDir).rgb * NdotL;
+            totalWeight += NdotL;
+        }
+    }
+    prefilteredColor /= max(totalWeight, 0.001);
+    filtered.write(float4(prefilteredColor, 1.0), gid.xy, face);
+}
+
+// Diffuse irradiance convolution
+kernel void irradiance_convolution(
+    texturecube<float, access::sample> envMap [[texture(0)]],
+    texturecube<float, access::write> irradiance [[texture(1)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    uint face = gid.z;
+    uint size = irradiance.get_width();
+    if (gid.x >= size || gid.y >= size) return;
+
+    float2 uv = (float2(gid.xy) + 0.5) / float(size) * 2.0 - 1.0;
+    float3 N;
+    switch (face) {
+        case 0: N = normalize(float3( 1.0, -uv.y, -uv.x)); break;
+        case 1: N = normalize(float3(-1.0, -uv.y,  uv.x)); break;
+        case 2: N = normalize(float3( uv.x,  1.0,  uv.y)); break;
+        case 3: N = normalize(float3( uv.x, -1.0, -uv.y)); break;
+        case 4: N = normalize(float3( uv.x, -uv.y,  1.0)); break;
+        case 5: N = normalize(float3(-uv.x, -uv.y, -1.0)); break;
+        default: N = float3(0); break;
+    }
+
+    constexpr sampler s(filter::linear, address::repeat);
+    float3 irr = float3(0.0);
+    float3 up = abs(N.z) < 0.999 ? float3(0, 0, 1) : float3(1, 0, 0);
+    float3 right = normalize(cross(up, N));
+    up = cross(N, right);
+
+    float sampleDelta = 0.05;
+    float nrSamples = 0.0;
+    for (float phi = 0.0; phi < 2.0 * M_PI_F; phi += sampleDelta) {
+        for (float theta = 0.0; theta < 0.5 * M_PI_F; theta += sampleDelta) {
+            float3 tangentSample = float3(sin(theta) * cos(phi),
+                                           sin(theta) * sin(phi),
+                                           cos(theta));
+            float3 sampleVec = tangentSample.x * right + tangentSample.y * up + tangentSample.z * N;
+            irr += envMap.sample(s, sampleVec).rgb * cos(theta) * sin(theta);
+            nrSamples += 1.0;
+        }
+    }
+    irr = M_PI_F * irr / max(nrSamples, 1.0);
+    irradiance.write(float4(irr, 1.0), gid.xy, face);
+}
+
+// BRDF integration LUT (2D texture, x=NdotV, y=roughness → (scale, bias))
+kernel void brdf_integration(
+    texture2d<float, access::write> lut [[texture(0)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    uint size = lut.get_width();
+    if (gid.x >= size || gid.y >= size) return;
+
+    float NdotV = (float(gid.x) + 0.5) / float(size);
+    float roughness = (float(gid.y) + 0.5) / float(size);
+    NdotV = max(NdotV, 0.001);
+
+    float3 V;
+    V.x = sqrt(1.0 - NdotV * NdotV);
+    V.y = 0.0;
+    V.z = NdotV;
+
+    float A = 0.0;
+    float B = 0.0;
+    float3 N = float3(0.0, 0.0, 1.0);
+    const uint SAMPLE_COUNT = 256u;
+
+    for (uint i = 0u; i < SAMPLE_COUNT; i++) {
+        float fi = float(i);
+        uint bits = i;
+        bits = (bits << 16u) | (bits >> 16u);
+        bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+        bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+        bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+        bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+        float2 Xi = float2(fi / float(SAMPLE_COUNT), float(bits) * 2.3283064365386963e-10);
+
+        float a = roughness * roughness;
+        float phi = 2.0 * M_PI_F * Xi.x;
+        float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+        float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+        float3 H = float3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+        float3 L = normalize(2.0 * dot(V, H) * H - V);
+
+        float NdotL_s = max(L.z, 0.0);
+        float NdotH = max(H.z, 0.0);
+        float VdotH = max(dot(V, H), 0.0);
+
+        if (NdotL_s > 0.0) {
+            float G = geometrySmith(NdotV, NdotL_s, roughness);
+            float G_Vis = (G * VdotH) / (NdotH * NdotV + 0.0001);
+            float Fc = pow(1.0 - VdotH, 5.0);
+            A += (1.0 - Fc) * G_Vis;
+            B += Fc * G_Vis;
+        }
+    }
+    A /= float(SAMPLE_COUNT);
+    B /= float(SAMPLE_COUNT);
+    lut.write(float4(A, B, 0.0, 1.0), gid);
 }

--- a/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
+++ b/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
@@ -238,11 +238,16 @@ fragment ShadedFragmentOut shaded_fragment(
         Lo *= mix(1.0 - shadowDarkness, 1.0, shadowFactor);
     }
 
-    // Hemisphere ambient: blend ground→sky based on normal Y
+    // Tri-axis ambient: vary ambient by normal in all 3 directions (not just Y)
+    // This breaks up uniform color on faces at the same elevation but different azimuths
     float3 skyColor = uniforms.ambientSkyColor.rgb;
     float3 groundColor = uniforms.ambientGroundColor.rgb;
-    float hemiBlend = N.y * 0.5 + 0.5;
-    float3 ambient = mix(groundColor, skyColor, hemiBlend) * bodyColor * (1.0 - metallic * 0.5);
+    float3 ambientY = mix(groundColor, skyColor, N.y * 0.5 + 0.5);
+    // Side axis: warm on +X, cool on -X (simulates fill/key side difference)
+    float3 ambientX = mix(float3(0.35, 0.30, 0.28), float3(0.28, 0.30, 0.35), N.x * 0.5 + 0.5);
+    // Depth axis: slightly brighter facing camera, darker facing away
+    float3 ambientZ = mix(float3(0.25, 0.25, 0.27), float3(0.32, 0.32, 0.30), N.z * 0.5 + 0.5);
+    float3 ambient = ((ambientY * 0.6) + (ambientX * 0.2) + (ambientZ * 0.2)) * bodyColor * (1.0 - metallic * 0.5);
 
     // Environment reflection approximation
     float3 R = reflect(-V, N);
@@ -257,6 +262,28 @@ fragment ShadedFragmentOut shaded_fragment(
 
     // Combine lighting
     float3 litColor = Lo + ambient + envContribution + rimColor;
+
+    // Screen-space curvature: brightens convex edges, darkens concave creases
+    // Uses fragment derivatives of the world normal to detect surface curvature.
+    // Suppressed at mesh boundaries where derivatives are discontinuous.
+    {
+        float3 dx = dfdx(N);
+        float3 dy = dfdy(N);
+        float derivMag = length(dx) + length(dy);
+        // Only apply curvature where derivatives are smooth (not at triangle seams)
+        if (derivMag < 1.5) {
+            float3 xneg = N - dx;
+            float3 xpos = N + dx;
+            float3 yneg = N - dy;
+            float3 ypos = N + dy;
+            float depth = in.clipPositionCopy.w;
+            float curvature = (cross(xneg, xpos).y - cross(yneg, ypos).x) * 4.0 / max(depth, 0.01);
+            // Smooth falloff near the derivative threshold to avoid hard transitions
+            float strength = 0.15 * smoothstep(1.5, 0.5, derivMag);
+            curvature = clamp(curvature, -1.0, 1.0);
+            litColor *= 1.0 + curvature * strength;
+        }
+    }
 
     // Matcap
     if (matcapBlend > 0.001) {
@@ -596,27 +623,34 @@ fragment float4 ssao_fragment(
 
     // --- SSAO ---
     if (params.intensity > 0.001) {
-        const float2 offsets[8] = {
+        // Two-ring sample pattern: inner ring (tight creases) + outer ring (broader AO)
+        const float2 offsets[16] = {
+            // Inner ring (radius 1.0) — catches tight internal angles
             float2(-1.0,  0.0), float2( 1.0,  0.0),
             float2( 0.0, -1.0), float2( 0.0,  1.0),
             float2(-0.707, -0.707), float2( 0.707, -0.707),
-            float2(-0.707,  0.707), float2( 0.707,  0.707)
+            float2(-0.707,  0.707), float2( 0.707,  0.707),
+            // Outer ring (radius 2.0) — broader ambient occlusion
+            float2(-2.0,  0.0), float2( 2.0,  0.0),
+            float2( 0.0, -2.0), float2( 0.0,  2.0),
+            float2(-1.414, -1.414), float2( 1.414, -1.414),
+            float2(-1.414,  1.414), float2( 1.414,  1.414)
         };
 
         float occlusion = 0.0;
         float scaledRadius = params.radius / max(linearDepth, 0.1);
 
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < 16; i++) {
             float2 sampleUV = in.texCoord + offsets[i] * scaledRadius * params.texelSize * 4.0;
             float sampleDepth = depthTexture.sample(pointSampler, sampleUV).r;
             float sampleLinear = linearizeDepth(sampleDepth, params.nearPlane, params.farPlane);
 
             float diff = linearDepth - sampleLinear;
             float rangeCheck = smoothstep(0.0, 1.0, scaledRadius / (abs(diff) + 0.001));
-            occlusion += step(0.001, diff) * rangeCheck;
+            occlusion += step(0.0005, diff) * rangeCheck;
         }
 
-        result_ao = 1.0 - (occlusion / 8.0) * params.intensity;
+        result_ao = 1.0 - (occlusion / 16.0) * params.intensity;
         result_ao = clamp(result_ao, 0.0, 1.0);
     }
 
@@ -645,9 +679,58 @@ fragment float4 ssao_fragment(
         result_edge = smoothstep(0.02, 0.15, edgeMag) * params.silhouetteIntensity;
     }
 
-    // Combine: darken by AO and edge
-    float3 finalColor = sceneColor.rgb * result_ao;
+    // --- Depth Unsharp Masking ---
+    // Computes average depth in a neighborhood and boosts contrast where depth
+    // deviates from the local average, enhancing perception of depth separation
+    // between adjacent faces. Only uses samples at similar depths to avoid
+    // silhouette halo artifacts.
+    float depthContrast = 1.0;
+    if (params.intensity > 0.001) {
+        float blurredDepth = 0.0;
+        float validSamples = 0.0;
+        const float2 unsharpOffsets[8] = {
+            float2(-3.0,  0.0), float2( 3.0,  0.0),
+            float2( 0.0, -3.0), float2( 0.0,  3.0),
+            float2(-2.12, -2.12), float2( 2.12, -2.12),
+            float2(-2.12,  2.12), float2( 2.12,  2.12)
+        };
+        for (int i = 0; i < 8; i++) {
+            float2 sampleUV = in.texCoord + unsharpOffsets[i] * params.texelSize * 3.0;
+            float rawDepth = depthTexture.sample(pointSampler, sampleUV).r;
+            // Skip background samples to avoid silhouette halos
+            if (rawDepth > 0.9999) continue;
+            float sd = linearizeDepth(rawDepth, params.nearPlane, params.farPlane);
+            // Skip samples at very different depths (silhouette boundary)
+            if (abs(sd - linearDepth) / max(linearDepth, 0.01) > 0.3) continue;
+            blurredDepth += sd;
+            validSamples += 1.0;
+        }
+
+        if (validSamples > 2.0) {
+            blurredDepth /= validSamples;
+            float spatialImportance = (linearDepth - blurredDepth) / max(linearDepth, 0.01);
+            depthContrast = 1.0 + spatialImportance * 0.2;
+            depthContrast = clamp(depthContrast, 0.85, 1.15);
+        }
+    }
+
+    // Combine: darken by AO, edge silhouettes, and depth contrast
+    float3 finalColor = sceneColor.rgb * result_ao * depthContrast;
     finalColor = mix(finalColor, float3(0.1, 0.1, 0.12), result_edge);
+
+    // --- ACES Filmic Tone Mapping ---
+    // Compresses dynamic range so highlights don't clip and shadows retain detail.
+    // Uses the Narkowicz ACES approximation (industry standard).
+    {
+        float exposure = 1.1;
+        float3 x = finalColor * exposure;
+        float a = 2.51;
+        float b = 0.03;
+        float c = 2.43;
+        float d = 0.59;
+        float e = 0.14;
+        finalColor = saturate((x * (a * x + b)) / (x * (c * x + d) + e));
+    }
 
     return float4(finalColor, sceneColor.a);
 }

--- a/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
+++ b/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
@@ -419,10 +419,19 @@ fragment WireframeFragmentOut wireframe_fragment(
         }
     }
 
+    float3 bodyColor = bodyUniforms.color.rgb;
+    float bodyAlpha = bodyUniforms.color.a;
+
+    // Edge-only bodies (metallic == -1 sentinel): use body color directly
+    if (bodyUniforms.metallic < 0.0) {
+        WireframeFragmentOut out;
+        out.color = float4(bodyColor, bodyAlpha);
+        return out;
+    }
+
     float edgeIntensity = max(uniforms.shadowParams.w, 0.0); // shadowParams.w = edge intensity
 
     // Contrast-adaptive edge color: light edges on dark bodies, dark edges on light bodies
-    float3 bodyColor = bodyUniforms.color.rgb;
     float luminance = dot(bodyColor, float3(0.299, 0.587, 0.114));
     // At intensity 1.0: darkEdge = bodyColor*0.4, lightEdge = bodyColor*0.5+0.5 (original)
     // At higher intensity: push edges darker/more contrasting

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -12,6 +12,8 @@ import SwiftUI
 struct LightDataSwift {
     var directionAndIntensity: SIMD4<Float>  // xyz = direction, w = intensity
     var colorAndEnabled: SIMD4<Float>        // rgb = color, a = enabled flag
+    var typeAndParams: SIMD4<Float>          // x = type (0=directional, 1=point), y = radius, z/w = unused
+    var positionAndPad: SIMD4<Float>         // xyz = world position (point lights), w = unused
 }
 
 struct Uniforms {
@@ -26,7 +28,9 @@ struct Uniforms {
     var ambientGroundColor: SIMD4<Float>      // rgb + specularIntensity in w
     var materialParams: SIMD4<Float>          // fresnelPower, fresnelIntensity, matcapBlend, farPlane
     var lightViewProjectionMatrix: simd_float4x4  // for shadow mapping
-    var shadowParams: SIMD4<Float>            // x = bias, y = intensity, z = enabled (1/0), w = unused
+    var shadowParams: SIMD4<Float>            // x = bias, y = intensity, z = enabled (1/0), w = edgeIntensity
+    var shadowParams2: SIMD4<Float> = .zero   // x = lightSize, y = searchRadius, z/w = unused (PCSS)
+    var iblParams: SIMD4<Float> = .zero       // x = intensity, y/z = unused, w = hasEnvMap
     var clipPlanes: (SIMD4<Float>, SIMD4<Float>, SIMD4<Float>, SIMD4<Float>) = (.zero, .zero, .zero, .zero)
     var clipPlaneCount: UInt32 = 0
     var _clipPad: SIMD3<Float> = .zero
@@ -73,6 +77,19 @@ struct SSAOParamsSwift {
     var farPlane: Float
     var silhouetteThickness: Float
     var silhouetteIntensity: Float
+    var exposure: Float
+    var whitePoint: Float
+    var dofAperture: Float
+    var dofFocalDistance: Float
+    var dofMaxBlurRadius: Float
+    var dofEnabled: Float
+}
+
+struct TAAParamsSwift {
+    var blendFactor: Float
+    var _pad0: Float = 0
+    var jitterOffset: SIMD2<Float>
+    var texelSize: SIMD2<Float>
 }
 
 // MARK: - Cached Body Buffers
@@ -128,6 +145,16 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
     private var resolvedDepthTexture: MTLTexture?
     private var resolvedWidth: Int = 0
     private var resolvedHeight: Int = 0
+
+    // TAA
+    private let taaPipeline: MTLRenderPipelineState?
+    private var taaHistoryTexture: MTLTexture?
+    private var taaOutputTexture: MTLTexture?
+    private var taaFrameIndex: UInt32 = 0
+    private var lastCameraState: CameraState?
+
+    // Environment map IBL
+    private var environmentMapManager: EnvironmentMapManager?
 
     private weak var controller: ViewportController?
     private var bodiesBinding: Binding<[ViewportBody]>
@@ -345,6 +372,14 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         // No depth needed for this fullscreen pass
         self.ssaoPipeline = try? device.makeRenderPipelineState(descriptor: ssaoDesc)
 
+        // TAA resolve pipeline (1x fullscreen pass)
+        let taaDesc = MTLRenderPipelineDescriptor()
+        taaDesc.label = "taa_resolve"
+        taaDesc.vertexFunction = library.makeFunction(name: "fullscreen_vertex")
+        taaDesc.fragmentFunction = library.makeFunction(name: "taa_resolve_fragment")
+        taaDesc.colorAttachments[0].pixelFormat = .bgra8Unorm
+        self.taaPipeline = try? device.makeRenderPipelineState(descriptor: taaDesc)
+
         // Depth stencil state
         let depthDesc = MTLDepthStencilDescriptor()
         depthDesc.depthCompareFunction = .less
@@ -486,6 +521,9 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         }
         self.pickReadbackBuffer = readback
 
+        // Environment map manager (IBL)
+        self.environmentMapManager = EnvironmentMapManager(device: device, library: library)
+
         super.init()
     }
 
@@ -493,6 +531,16 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
 
     /// The Metal device, exposed for MTKView configuration.
     public var metalDevice: MTLDevice { device }
+
+    /// Loads an equirectangular HDR image as the environment map for IBL.
+    public func loadEnvironmentMap(data: Data) {
+        environmentMapManager?.loadEquirectangular(data: data, commandQueue: commandQueue)
+    }
+
+    /// Clears the current environment map.
+    public func clearEnvironmentMap() {
+        environmentMapManager?.clear()
+    }
 
     /// Invalidates cached buffers so they are rebuilt on next draw.
     public func invalidateBuffers() {
@@ -545,6 +593,38 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         resolvedHeight = height
     }
 
+    /// Ensures TAA history + output textures exist at the given size.
+    private func ensureTAATextures(width: Int, height: Int) {
+        guard width > 0, height > 0 else { return }
+        if let existing = taaHistoryTexture, existing.width == width, existing.height == height { return }
+
+        let desc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        desc.usage = [.renderTarget, .shaderRead]
+        desc.storageMode = .private
+
+        taaHistoryTexture = device.makeTexture(descriptor: desc)
+        taaOutputTexture = device.makeTexture(descriptor: desc)
+        taaFrameIndex = 0
+    }
+
+    /// Halton sequence value for sub-pixel jitter.
+    private func halton(index: UInt32, base: UInt32) -> Float {
+        var f: Float = 1.0
+        var r: Float = 0.0
+        var i = index
+        while i > 0 {
+            f /= Float(base)
+            r += f * Float(i % base)
+            i /= base
+        }
+        return r
+    }
+
     /// Ensures the 1x depth texture for the pick pass matches the given size.
     private func ensurePickDepthTexture(width: Int, height: Int) {
         guard width > 0, height > 0 else { return }
@@ -586,9 +666,21 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         // Pack lights from lighting configuration
         let lightSources = [lighting.keyLight, lighting.fillLight, lighting.backLight]
         func packLight(_ ls: LightSettings) -> LightDataSwift {
-            LightDataSwift(
+            let typeVal: Float
+            let radiusVal: Float
+            switch ls.lightType {
+            case .directional:
+                typeVal = 0.0
+                radiusVal = 0.0
+            case .point(let radius):
+                typeVal = 1.0
+                radiusVal = radius
+            }
+            return LightDataSwift(
                 directionAndIntensity: SIMD4<Float>(ls.direction.x, ls.direction.y, ls.direction.z, ls.intensity),
-                colorAndEnabled: SIMD4<Float>(ls.color.x, ls.color.y, ls.color.z, ls.isEnabled ? 1.0 : 0.0)
+                colorAndEnabled: SIMD4<Float>(ls.color.x, ls.color.y, ls.color.z, ls.isEnabled ? 1.0 : 0.0),
+                typeAndParams: SIMD4<Float>(typeVal, radiusVal, 0, 0),
+                positionAndPad: SIMD4<Float>(ls.position.x, ls.position.y, ls.position.z, 0)
             )
         }
 
@@ -617,6 +709,19 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         }()
         let clipPlaneCount = UInt32(activeClipPlanes.count)
 
+        let shadowParams2 = SIMD4<Float>(
+            lighting.shadowLightSize,
+            lighting.shadowSearchRadius,
+            0, 0
+        )
+
+        let hasEnvMap: Float = (environmentMapManager?.hasEnvironmentMap ?? false) ? 1.0 : 0.0
+        let iblParams = SIMD4<Float>(
+            lighting.environmentIntensity,
+            0, 0,
+            hasEnvMap
+        )
+
         func makeUniforms() -> Uniforms {
             Uniforms(
                 viewProjectionMatrix: viewProjection,
@@ -631,6 +736,8 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 materialParams: SIMD4<Float>(lighting.fresnelPower, lighting.fresnelIntensity, lighting.matcapBlend, farPlane),
                 lightViewProjectionMatrix: lightVP,
                 shadowParams: shadowParams,
+                shadowParams2: shadowParams2,
+                iblParams: iblParams,
                 clipPlanes: clipPlaneVecs,
                 clipPlaneCount: clipPlaneCount
             )
@@ -653,11 +760,15 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
 
         let silhouettesEnabled = controller.configuration.enableSilhouettes
         let ssaoEnabled = (lighting.enableSSAO || silhouettesEnabled) && ssaoPipeline != nil
+        let taaEnabled = controller.enableTAA && taaPipeline != nil
         let w = Int(drawableSize.width)
         let h = Int(drawableSize.height)
 
-        if ssaoEnabled {
+        if ssaoEnabled || taaEnabled {
             ensureResolvedTextures(width: w, height: h)
+        }
+        if taaEnabled {
+            ensureTAATextures(width: w, height: h)
         }
 
         guard let commandBuffer = commandQueue.makeCommandBuffer() else { return }
@@ -712,8 +823,8 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         // =========================================================
         renderPassDescriptor.colorAttachments[1].texture = nil
 
-        // When SSAO is enabled, redirect MSAA resolve to our intermediate texture
-        if ssaoEnabled, let resolvedColor = resolvedColorTexture {
+        // When SSAO or TAA is enabled, redirect MSAA resolve to our intermediate texture
+        if (ssaoEnabled || taaEnabled), let resolvedColor = resolvedColorTexture {
             if msaaSampleCount > 1 {
                 renderPassDescriptor.colorAttachments[0].resolveTexture = resolvedColor
             } else {
@@ -773,6 +884,11 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 mainEncoder.setFragmentTexture(matcapTexture, index: 0)
                 if shadowEnabled, let shadowTex = shadowMapManager.texture {
                     mainEncoder.setFragmentTexture(shadowTex, index: 1)
+                }
+                if let envMgr = environmentMapManager, envMgr.hasEnvironmentMap {
+                    if let spec = envMgr.prefilteredSpecularMap { mainEncoder.setFragmentTexture(spec, index: 2) }
+                    if let diff = envMgr.irradianceMap { mainEncoder.setFragmentTexture(diff, index: 3) }
+                    if let brdf = envMgr.brdfLUT { mainEncoder.setFragmentTexture(brdf, index: 4) }
                 }
                 mainEncoder.drawIndexedPrimitives(
                     type: .triangle,
@@ -905,10 +1021,66 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         }
 
         // =========================================================
+        // Pass 2.5: TAA resolve (if enabled)
+        // =========================================================
+        if taaEnabled, let taaPipeline = taaPipeline,
+           let resolvedColor = resolvedColorTexture,
+           let taaOutput = taaOutputTexture,
+           let taaHistory = taaHistoryTexture {
+
+            // Check if camera moved
+            let cameraChanged = (lastCameraState == nil || lastCameraState! != cameraState)
+            if cameraChanged {
+                taaFrameIndex = 0
+            }
+
+            let taaPass = MTLRenderPassDescriptor()
+            taaPass.colorAttachments[0].texture = taaOutput
+            taaPass.colorAttachments[0].loadAction = .dontCare
+            taaPass.colorAttachments[0].storeAction = .store
+
+            if let taaEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: taaPass) {
+                taaEncoder.setRenderPipelineState(taaPipeline)
+
+                let blendFactor = taaFrameIndex > 0 ? controller.taaBlendFactor : Float(0.0)
+                let jitterX = halton(index: taaFrameIndex, base: 2) - 0.5
+                let jitterY = halton(index: taaFrameIndex, base: 3) - 0.5
+
+                var taaParams = TAAParamsSwift(
+                    blendFactor: blendFactor,
+                    jitterOffset: SIMD2<Float>(jitterX, jitterY),
+                    texelSize: SIMD2<Float>(1.0 / Float(w), 1.0 / Float(h))
+                )
+                taaEncoder.setFragmentTexture(resolvedColor, index: 0)
+                taaEncoder.setFragmentTexture(taaHistory, index: 1)
+                taaEncoder.setFragmentBytes(&taaParams, length: MemoryLayout<TAAParamsSwift>.size, index: 0)
+                taaEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
+                taaEncoder.endEncoding()
+            }
+
+            // Swap history: blit taaOutput → taaHistory for next frame
+            if let blitEncoder = commandBuffer.makeBlitCommandEncoder() {
+                blitEncoder.copy(from: taaOutput, to: taaHistory)
+                blitEncoder.endEncoding()
+            }
+
+            lastCameraState = cameraState
+            taaFrameIndex = (taaFrameIndex + 1) % 16
+        }
+
+        // Determine which color texture to feed into SSAO
+        let ssaoInputColor: MTLTexture? = {
+            if taaEnabled, let taaOutput = taaOutputTexture {
+                return taaOutput
+            }
+            return resolvedColorTexture
+        }()
+
+        // =========================================================
         // Pass 3: SSAO post-process (if enabled)
         // =========================================================
         if ssaoEnabled, let ssaoPipeline = ssaoPipeline,
-           let resolvedColor = resolvedColorTexture,
+           let resolvedColor = ssaoInputColor,
            let resolvedDepth = resolvedDepthTexture {
 
             // First: render a 1x depth-only pass for SSAO sampling
@@ -957,6 +1129,25 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 ssaoEncoder.setRenderPipelineState(ssaoPipeline)
 
                 let silhouetteConfig = controller.configuration
+                let dofEnabled = controller.enableDepthOfField
+                var dofFocalDist = controller.dofFocalDistance
+                if dofEnabled && dofFocalDist == 0 {
+                    // Auto-focus: use distance to scene center
+                    var sceneCenter = SIMD3<Float>.zero
+                    var count: Float = 0
+                    for body in bodies where body.isVisible {
+                        if let bb = body.boundingBox {
+                            sceneCenter += (bb.min + bb.max) * 0.5
+                            count += 1
+                        }
+                    }
+                    if count > 0 {
+                        sceneCenter /= count
+                        dofFocalDist = simd_distance(cameraState.position, sceneCenter)
+                    } else {
+                        dofFocalDist = cameraState.distance
+                    }
+                }
                 var ssaoParams = SSAOParamsSwift(
                     texelSize: SIMD2<Float>(1.0 / Float(w), 1.0 / Float(h)),
                     radius: lighting.ssaoRadius,
@@ -964,7 +1155,13 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                     nearPlane: nearPlane,
                     farPlane: farPlane,
                     silhouetteThickness: silhouetteConfig.enableSilhouettes ? silhouetteConfig.silhouetteThickness : 0.0,
-                    silhouetteIntensity: silhouetteConfig.enableSilhouettes ? silhouetteConfig.silhouetteIntensity : 0.0
+                    silhouetteIntensity: silhouetteConfig.enableSilhouettes ? silhouetteConfig.silhouetteIntensity : 0.0,
+                    exposure: lighting.exposure,
+                    whitePoint: lighting.whitePoint,
+                    dofAperture: controller.dofAperture,
+                    dofFocalDistance: dofFocalDist,
+                    dofMaxBlurRadius: controller.dofMaxBlurRadius,
+                    dofEnabled: dofEnabled ? 1.0 : 0.0
                 )
                 ssaoEncoder.setFragmentTexture(resolvedDepth, index: 0)
                 ssaoEncoder.setFragmentTexture(resolvedColor, index: 1)

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -786,11 +786,17 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             // Wireframe/edge pass
             let shouldDrawEdges = hasEdges && (displayMode.showsEdges || !hasMesh)
             if shouldDrawEdges, let edgeVB = buffers.edgeVertexBuffer {
+                // For edge-only bodies, signal the shader to use the body color directly
+                // instead of contrast-adaptive edge color (metallic = -1 sentinel)
+                var edgeBodyUniforms = bodyUniforms
+                if !hasMesh {
+                    edgeBodyUniforms.metallic = -1.0
+                }
                 mainEncoder.setRenderPipelineState(wireframePipeline)
                 mainEncoder.setVertexBuffer(edgeVB, offset: 0, index: 0)
                 mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
                 mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
-                mainEncoder.setFragmentBytes(&bodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
+                mainEncoder.setFragmentBytes(&edgeBodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
                 mainEncoder.drawPrimitives(type: .line, vertexStart: 0, vertexCount: buffers.edgeVertexCount)
             }
 

--- a/Sources/OCCTSwiftViewport/Views/ViewportController.swift
+++ b/Sources/OCCTSwiftViewport/Views/ViewportController.swift
@@ -78,6 +78,26 @@ public final class ViewportController: ObservableObject {
     /// Current measurement interaction mode.
     @Published public var measurementMode: MeasurementMode = .none
 
+    // MARK: - Post-Process Toggles (runtime-tunable)
+
+    /// Whether depth of field is enabled.
+    @Published public var enableDepthOfField: Bool = false
+
+    /// DoF aperture (smaller = shallower).
+    @Published public var dofAperture: Float = 2.8
+
+    /// DoF focal distance (0 = autofocus).
+    @Published public var dofFocalDistance: Float = 0
+
+    /// Maximum DoF blur radius in pixels.
+    @Published public var dofMaxBlurRadius: Float = 8.0
+
+    /// Whether temporal anti-aliasing is enabled.
+    @Published public var enableTAA: Bool = false
+
+    /// TAA blend factor (0 = no history, 1 = full history).
+    @Published public var taaBlendFactor: Float = 0.9
+
     // MARK: - Configuration
 
     /// Viewport configuration.
@@ -111,6 +131,12 @@ public final class ViewportController: ObservableObject {
         self.showAxes = configuration.showAxes
         self.showGrid = configuration.showGrid
         self.lightingConfiguration = configuration.lightingConfiguration
+        self.enableDepthOfField = configuration.enableDepthOfField
+        self.dofAperture = configuration.dofAperture
+        self.dofFocalDistance = configuration.dofFocalDistance
+        self.dofMaxBlurRadius = configuration.dofMaxBlurRadius
+        self.enableTAA = configuration.enableTAA
+        self.taaBlendFactor = configuration.taaBlendFactor
 
         self.cameraController = CameraController(initialState: configuration.initialCameraState)
         cameraController.rotationStyle = configuration.rotationStyle


### PR DESCRIPTION
## Summary
- **17 commits** spanning OCCT 8 feature demos (v0.30–v0.49), rendering upgrades, and bug fixes
- Complete demo gallery exercising 100+ OCCTSwift APIs across 15 interactive demos
- CADRays-inspired rendering: PCSS shadows, DoF, TAA, IBL, point lights, exposure/tone mapping
- Camera, wireframe, and STL loading fixes

## Demo coverage
| Version | Demo | Key APIs |
|---------|------|----------|
| v0.30 | OCCT 8 Basics | helix, KD-tree, wedge, hatch, shape ops |
| v0.31 | Curve/Surface | curve sampling, bezier fill, revolution, linear rib |
| v0.32–v0.34 | Enhanced rendering | projection, analysis |
| v0.35–v0.38 | Geometry ops | hollow, OBB, fuse & blend, variable offset |
| v0.39–v0.41 | More ops | free bounds, inertia, surgery, detection |
| v0.42–v0.43 | Solid construction | solidFromShells, fillet2D, BSpline fill, subdivision |
| v0.44 | Extrema & arcs | surface extrema, ellipse arcs, dihedral angle |
| v0.45 | Filling | FillingSurface, self-intersection, WireOrder |
| v0.46 | Concavity & inertia | edge concavity, localPrism, volume/surface inertia |
| v0.47 | Local ops & validation | localRevolution, draftPrism, constrainedFill, BRepCheck |
| v0.48 | Split ops & extrema | localPipe, splitEdge, intersectLine, edge/point/face extrema |
| v0.49 | Curve analysis | pointEdgeExtrema, curve joining, free bounds, UV projection |

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 37 tests in 9 suites all passing
- [x] Deployed to iPhone and verified demos interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)