### PR TITLE
fix: guard quantize() against Int32 overflow / non-finite coords (closes #30)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/NormalSmoothing.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/NormalSmoothing.swift
@@ -134,13 +134,23 @@ public enum NormalSmoothing {
     }
 
     /// Quantizes a position to a grid for spatial hashing (tolerance ~1e-5).
+    ///
+    /// Non-finite coordinates map to 0 and coordinates beyond the Int32 range are
+    /// clamped, so an out-of-range or `NaN`/`±inf` tessellation vertex can never trap
+    /// the trapping `Int32(_: Float)` initializer. This only affects the welding key:
+    /// welding matters only for near-coincident vertices, so a clamped extreme simply
+    /// fails to weld with anything, which is correct.
     private static func quantize(_ p: SIMD3<Float>) -> SIMD3<Int32> {
         let scale: Float = 1e5
-        return SIMD3<Int32>(
-            Int32(round(p.x * scale)),
-            Int32(round(p.y * scale)),
-            Int32(round(p.z * scale))
-        )
+        // Inside the Int32 range and exactly representable as Float. Clamping to
+        // Float(Int32.max) would itself trap, since that rounds up to 2³¹.
+        let limit: Float = 2_000_000_000
+        func q(_ v: Float) -> Int32 {
+            let s = (v * scale).rounded()
+            guard s.isFinite else { return 0 }
+            return Int32(min(max(s, -limit), limit))
+        }
+        return SIMD3<Int32>(q(p.x), q(p.y), q(p.z))
     }
 
     /// Groups triangle indices by crease-angle connectivity.

--- a/Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift
+++ b/Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift
@@ -1,0 +1,72 @@
+// NormalSmoothingTests.swift
+// OCCTSwiftViewport Tests
+//
+// Crease-aware normal smoothing — including the Int32-overflow guard (issue #30).
+
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@Suite("Normal smoothing")
+struct NormalSmoothingTests {
+
+    /// Builds an interleaved `[px,py,pz, nx,ny,nz]` buffer (stride 6) from positions,
+    /// seeding every normal with a placeholder so smoothing has something to overwrite.
+    private func interleaved(_ positions: [SIMD3<Float>]) -> [Float] {
+        var data: [Float] = []
+        data.reserveCapacity(positions.count * 6)
+        for p in positions {
+            data += [p.x, p.y, p.z, 0, 0, 1]
+        }
+        return data
+    }
+
+    // MARK: - Regression: issue #30 — quantize() must not trap
+
+    @Test("Vertex beyond the ±21,474.8 welding-scale ceiling does not trap")
+    func largeCoordinateDoesNotTrap() {
+        // 30,000 model units * 1e5 scale ≈ 3e9 > Int32.max (~2.147e9): the old
+        // Int32(round(...)) initializer trapped here. Reaching the assertion at all
+        // proves the clamp held.
+        var data = interleaved([
+            SIMD3(30_000, 0, 0),
+            SIMD3(30_001, 1, 0),
+            SIMD3(30_000, 0, 1),
+        ])
+        NormalSmoothing.smoothNormals(vertexData: &data, indices: [0, 1, 2])
+        #expect(data.count == 18)
+    }
+
+    @Test("Non-finite coordinates (NaN / ±inf) do not trap")
+    func nonFiniteCoordinatesDoNotTrap() {
+        var data = interleaved([
+            SIMD3(.nan, 0, 0),
+            SIMD3(0, .infinity, 0),
+            SIMD3(0, 0, -.infinity),
+        ])
+        NormalSmoothing.smoothNormals(vertexData: &data, indices: [0, 1, 2])
+        #expect(data.count == 18)
+    }
+
+    // MARK: - Sanity: in-range smoothing still averages shared normals
+
+    @Test("Coplanar shared vertices average to the shared face normal")
+    func coplanarVerticesSmoothToFaceNormal() {
+        // Two triangles forming a flat quad in the z=0 plane share the (1,0,0) and
+        // (0,1,0) corners. Their face normals are identical (+Z), so the shared
+        // vertices should average to a clean +Z normal.
+        var data = interleaved([
+            SIMD3(0, 0, 0), // 0
+            SIMD3(1, 0, 0), // 1 (shared)
+            SIMD3(0, 1, 0), // 2 (shared)
+            SIMD3(1, 1, 0), // 3
+        ])
+        NormalSmoothing.smoothNormals(vertexData: &data, indices: [0, 1, 2, 1, 3, 2])
+
+        // Vertex 1's normal (offset 1*6 + 3) should be +Z.
+        let n1 = SIMD3<Float>(data[9], data[10], data[11])
+        #expect(abs(n1.z - 1) < 1e-5)
+        #expect(abs(n1.x) < 1e-5)
+        #expect(abs(n1.y) < 1e-5)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #30. `NormalSmoothing.quantize(_:)` did `Int32(round(coord * 1e5))` with no range or finiteness guard, so any tessellated mesh vertex whose coordinate exceeded **±21,474.8** model units (or was `NaN`/`±inf`) trapped the process via the trapping `Int32(_: Float)` initializer:

```
Fatal error: Float value cannot be converted to Int32 because the result would be greater than Int32.max
```

This is an uncatchable `fatalError` (not a thrown `Error`), so it crashed **every** body load that hit it through `CADFileLoader.loadFromManifest` — triggered both by legitimately large models (>~21.4 m in mm units) and by ill-bounded/untrimmed faces that tessellate to vertices far outside the part's real bounding box.

## Fix

`Sources/OCCTSwiftViewport/Renderer/NormalSmoothing.swift` — guard finiteness and clamp into the Int32 range **before** converting:

```swift
let limit: Float = 2_000_000_000   // inside Int32 range, exactly representable
func q(_ v: Float) -> Int32 {
    let s = (v * scale).rounded()
    guard s.isFinite else { return 0 }
    return Int32(min(max(s, -limit), limit))
}
```

Note the pitfall called out in the issue: clamping to `Float(Int32.max)` would itself trap, since that rounds **up** to 2³¹ — hence the `2e9` limit, which is inside the range and exactly representable.

This only affects the spatial-hash welding key. Welding matters only for near-coincident vertices, so a clamped extreme simply fails to weld with anything — which is correct.

The optional follow-up from the issue (bbox-derived scale or `Int64` keys to remove the implicit ~21 km size cap) is intentionally **out of scope** for this crash fix.

## Tests

Adds `Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift`, driving the public `smoothNormals` API with:

- a 30,000-unit coordinate (overflows the old initializer)
- `NaN` / `±inf` coordinates

Both trap the process before this change. Plus an in-range sanity test confirming coplanar shared vertices still average to the correct shared face normal.

**64/64 tests pass** (was 61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)