### PR TITLE
feat(picking): composable SelectionFilter chains (closes #33)

### DIFF
--- a/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+++ b/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
@@ -127,6 +127,7 @@ public typealias _MeasurementMode = MeasurementMode
 public typealias _PickResult = PickResult
 public typealias _PrimitiveKind = PrimitiveKind
 public typealias _PickingConfiguration = PickingConfiguration
+public typealias _SelectionFilter = SelectionFilter
 
 // Dynamic Pivot
 public typealias _PivotStrategy = PivotStrategy

--- a/Sources/OCCTSwiftViewport/Picking/SelectionFilter.swift
+++ b/Sources/OCCTSwiftViewport/Picking/SelectionFilter.swift
@@ -1,0 +1,130 @@
+// SelectionFilter.swift
+// ViewportKit
+//
+// Composable predicate over pick results — a SelectMgr_Filter analogue.
+
+import Foundation
+
+/// A composable predicate that decides whether a `PickResult` is accepted as a
+/// selection.
+///
+/// This is the OCCTSwiftViewport analogue of OCCT's `SelectMgr_Filter` chain.
+/// Where OCCT filters sensitive entities before sorting, here the GPU pick pass
+/// has already resolved a single primitive, so a `SelectionFilter` runs on the
+/// decoded `PickResult` and either accepts it or rejects it. A rejected pick is
+/// treated as a miss — GPU picking reads exactly one primitive per pixel, so
+/// there is no alternate candidate to fall through to.
+///
+/// Assign one to `ViewportController.selectionFilter` to constrain what the
+/// user-geometry pick stream surfaces (e.g. "edges only", "everything except
+/// the construction body"). Widget-layer picks bypass the filter — that stream
+/// is owned by an external consumer (e.g. OCCTSwiftAIS manipulators).
+///
+/// Filters compose:
+/// ```swift
+/// controller.selectionFilter = .edges.or(.vertices)
+///                                    .and(.excludingBodyIDs(["grid"]))
+/// ```
+///
+/// - Note: Depth/distance filtering is intentionally absent: the GPU pick
+///   `PickResult` carries no depth value. Use the CPU `SceneRaycast` path if you
+///   need distance-aware filtering.
+public struct SelectionFilter: Sendable {
+
+    private let predicate: @Sendable (PickResult) -> Bool
+
+    /// Wraps an arbitrary predicate.
+    public init(_ predicate: @escaping @Sendable (PickResult) -> Bool) {
+        self.predicate = predicate
+    }
+
+    /// Returns `true` if the result passes this filter.
+    public func matches(_ result: PickResult) -> Bool {
+        predicate(result)
+    }
+
+    /// Lets a filter be called like a function: `filter(result)`.
+    public func callAsFunction(_ result: PickResult) -> Bool {
+        predicate(result)
+    }
+}
+
+// MARK: - Built-in filters
+
+extension SelectionFilter {
+
+    /// Accepts every result.
+    public static let all = SelectionFilter { _ in true }
+
+    /// Rejects every result.
+    public static let nothing = SelectionFilter { _ in false }
+
+    /// Accepts results of a single sub-shape kind.
+    public static func kind(_ kind: PrimitiveKind) -> SelectionFilter {
+        SelectionFilter { $0.kind == kind }
+    }
+
+    /// Accepts results whose kind is in the given set.
+    public static func kinds(_ kinds: Set<PrimitiveKind>) -> SelectionFilter {
+        SelectionFilter { kinds.contains($0.kind) }
+    }
+
+    /// Faces only.
+    public static let faces = kind(.face)
+
+    /// Edges only.
+    public static let edges = kind(.edge)
+
+    /// Vertices only.
+    public static let vertices = kind(.vertex)
+
+    /// Accepts results on a specific pick layer.
+    public static func layer(_ layer: PickLayer) -> SelectionFilter {
+        SelectionFilter { $0.pickLayer == layer }
+    }
+
+    /// Accepts results whose body ID is in the allow-list.
+    public static func bodyIDs(_ ids: Set<String>) -> SelectionFilter {
+        SelectionFilter { ids.contains($0.bodyID) }
+    }
+
+    /// Rejects results whose body ID is in the deny-list.
+    public static func excludingBodyIDs(_ ids: Set<String>) -> SelectionFilter {
+        SelectionFilter { !ids.contains($0.bodyID) }
+    }
+
+    /// Accepts results whose draw-order body index is in the given set.
+    public static func bodyIndices(_ indices: Set<Int>) -> SelectionFilter {
+        SelectionFilter { indices.contains($0.bodyIndex) }
+    }
+}
+
+// MARK: - Composition
+
+extension SelectionFilter {
+
+    /// Logical AND of this filter and another.
+    public func and(_ other: SelectionFilter) -> SelectionFilter {
+        SelectionFilter { self.matches($0) && other.matches($0) }
+    }
+
+    /// Logical OR of this filter and another.
+    public func or(_ other: SelectionFilter) -> SelectionFilter {
+        SelectionFilter { self.matches($0) || other.matches($0) }
+    }
+
+    /// Logical negation.
+    public var negated: SelectionFilter {
+        SelectionFilter { !self.matches($0) }
+    }
+
+    /// AND-combines a chain of filters. An empty chain accepts everything.
+    public static func all(of filters: [SelectionFilter]) -> SelectionFilter {
+        SelectionFilter { result in filters.allSatisfy { $0.matches(result) } }
+    }
+
+    /// OR-combines a chain of filters. An empty chain rejects everything.
+    public static func any(of filters: [SelectionFilter]) -> SelectionFilter {
+        SelectionFilter { result in filters.contains { $0.matches(result) } }
+    }
+}

--- a/Sources/OCCTSwiftViewport/Views/ViewportController.swift
+++ b/Sources/OCCTSwiftViewport/Views/ViewportController.swift
@@ -321,20 +321,30 @@ public final class ViewportController: ObservableObject {
     /// Optional callback invoked when a widget-layer pick occurs.
     public var onWidgetPick: ((PickResult?) -> Void)?
 
+    /// Optional filter constraining what the user-geometry pick stream accepts.
+    ///
+    /// When set, a user-geometry pick that fails the filter is treated as a miss
+    /// (clearing `pickResult`), since GPU picking resolves a single primitive per
+    /// pixel and has no alternate candidate to fall through to. Widget-layer picks
+    /// bypass the filter — that stream is owned by an external consumer.
+    public var selectionFilter: SelectionFilter?
+
     /// Called by the view layer after a GPU pick readback completes.
     ///
     /// Routes the result to either `pickResult` (default) or `widgetPickResult`
     /// based on the picked body's `pickLayer`. A nil result clears `pickResult`
     /// only — `widgetPickResult` keeps its last value, since the widget-pick
     /// stream is owned by an external consumer (e.g., AIS) that decides when to
-    /// reset it.
+    /// reset it. The user-geometry stream additionally honours `selectionFilter`.
     public func handlePick(result: PickResult?) {
         if let result, result.pickLayer == .widget {
             widgetPickResult = result
             onWidgetPick?(result)
         } else {
-            pickResult = result
-            onPick?(result)
+            // A result that fails the selection filter is treated as a miss.
+            let passed = result.flatMap { selectionFilter?.matches($0) == false ? nil : $0 }
+            pickResult = passed
+            onPick?(passed)
         }
     }
 

--- a/Tests/OCCTSwiftViewportTests/SelectionFilterTests.swift
+++ b/Tests/OCCTSwiftViewportTests/SelectionFilterTests.swift
@@ -1,0 +1,149 @@
+import Testing
+@testable import OCCTSwiftViewport
+
+@Suite("SelectionFilter Tests")
+struct SelectionFilterTests {
+
+    // Build a decoded PickResult for a given kind / object index / layer.
+    private static func make(kind: PrimitiveKind,
+                             objectIndex: UInt32 = 0,
+                             primitiveID: UInt32 = 0,
+                             layer: PickLayer = .userGeometry) -> PickResult {
+        let raw: UInt32 = (UInt32(kind.rawValue) << 30)
+            | ((primitiveID & 0x3FFF) << 16)
+            | (objectIndex & 0xFFFF)
+        let indexMap: [Int: String] = [0: "a", 1: "b", 2: "c"]
+        let layerMap: [String: PickLayer] = layer == .widget
+            ? [indexMap[Int(objectIndex)] ?? "a": .widget]
+            : [:]
+        return PickResult(rawValue: raw, indexMap: indexMap, layerMap: layerMap)!
+    }
+
+    // MARK: - Built-ins
+
+    @Test("all accepts everything, nothing rejects everything")
+    func allAndNothing() {
+        let face = Self.make(kind: .face)
+        #expect(SelectionFilter.all.matches(face))
+        #expect(!SelectionFilter.nothing.matches(face))
+    }
+
+    @Test("kind filters by sub-shape kind")
+    func kindFilter() {
+        #expect(SelectionFilter.edges.matches(Self.make(kind: .edge)))
+        #expect(!SelectionFilter.edges.matches(Self.make(kind: .face)))
+        #expect(SelectionFilter.faces.matches(Self.make(kind: .face)))
+        #expect(SelectionFilter.vertices.matches(Self.make(kind: .vertex)))
+    }
+
+    @Test("kinds set accepts any member")
+    func kindsSet() {
+        let f = SelectionFilter.kinds([.edge, .vertex])
+        #expect(f.matches(Self.make(kind: .edge)))
+        #expect(f.matches(Self.make(kind: .vertex)))
+        #expect(!f.matches(Self.make(kind: .face)))
+    }
+
+    @Test("layer filters by pick layer")
+    func layerFilter() {
+        let widgetOnly = SelectionFilter.layer(.widget)
+        #expect(widgetOnly.matches(Self.make(kind: .face, layer: .widget)))
+        #expect(!widgetOnly.matches(Self.make(kind: .face, layer: .userGeometry)))
+    }
+
+    @Test("bodyIDs allow-list and excludingBodyIDs deny-list")
+    func bodyIDFilters() {
+        let allow = SelectionFilter.bodyIDs(["a", "c"])
+        #expect(allow.matches(Self.make(kind: .face, objectIndex: 0)))   // "a"
+        #expect(!allow.matches(Self.make(kind: .face, objectIndex: 1)))  // "b"
+
+        let deny = SelectionFilter.excludingBodyIDs(["b"])
+        #expect(!deny.matches(Self.make(kind: .face, objectIndex: 1)))   // "b"
+        #expect(deny.matches(Self.make(kind: .face, objectIndex: 2)))    // "c"
+    }
+
+    @Test("bodyIndices filters by draw-order index")
+    func bodyIndexFilter() {
+        let f = SelectionFilter.bodyIndices([2])
+        #expect(f.matches(Self.make(kind: .face, objectIndex: 2)))
+        #expect(!f.matches(Self.make(kind: .face, objectIndex: 0)))
+    }
+
+    // MARK: - Composition
+
+    @Test("and requires both, or requires either, negated inverts")
+    func composition() {
+        let edgesOnB = SelectionFilter.edges.and(.bodyIDs(["b"]))
+        #expect(edgesOnB.matches(Self.make(kind: .edge, objectIndex: 1)))  // edge + "b"
+        #expect(!edgesOnB.matches(Self.make(kind: .face, objectIndex: 1))) // wrong kind
+        #expect(!edgesOnB.matches(Self.make(kind: .edge, objectIndex: 0))) // wrong body
+
+        let edgesOrVerts = SelectionFilter.edges.or(.vertices)
+        #expect(edgesOrVerts.matches(Self.make(kind: .vertex)))
+        #expect(!edgesOrVerts.matches(Self.make(kind: .face)))
+
+        let notFaces = SelectionFilter.faces.negated
+        #expect(!notFaces.matches(Self.make(kind: .face)))
+        #expect(notFaces.matches(Self.make(kind: .edge)))
+    }
+
+    @Test("all(of:) ANDs the chain; empty chain accepts")
+    func allOfChain() {
+        let chain = SelectionFilter.all(of: [.edges, .bodyIDs(["a"])])
+        #expect(chain.matches(Self.make(kind: .edge, objectIndex: 0)))
+        #expect(!chain.matches(Self.make(kind: .edge, objectIndex: 1)))
+        #expect(SelectionFilter.all(of: []).matches(Self.make(kind: .face)))
+    }
+
+    @Test("any(of:) ORs the chain; empty chain rejects")
+    func anyOfChain() {
+        let chain = SelectionFilter.any(of: [.faces, .vertices])
+        #expect(chain.matches(Self.make(kind: .face)))
+        #expect(chain.matches(Self.make(kind: .vertex)))
+        #expect(!chain.matches(Self.make(kind: .edge)))
+        #expect(!SelectionFilter.any(of: []).matches(Self.make(kind: .face)))
+    }
+
+    @Test("callAsFunction is equivalent to matches")
+    func callAsFunction() {
+        let f = SelectionFilter.faces
+        let face = Self.make(kind: .face)
+        #expect(f(face) == f.matches(face))
+    }
+
+    // MARK: - Controller integration
+
+    @MainActor
+    @Test("Controller applies filter to user-geometry stream, rejected pick clears")
+    func controllerFiltersUserStream() {
+        let controller = ViewportController()
+        controller.selectionFilter = .edges
+
+        controller.handlePick(result: Self.make(kind: .edge, objectIndex: 0))
+        #expect(controller.pickResult?.kind == .edge)
+
+        // A face fails the .edges filter → treated as a miss, clears pickResult.
+        controller.handlePick(result: Self.make(kind: .face, objectIndex: 0))
+        #expect(controller.pickResult == nil)
+    }
+
+    @MainActor
+    @Test("Widget-layer picks bypass the selection filter")
+    func widgetBypassesFilter() {
+        let controller = ViewportController()
+        controller.selectionFilter = .edges  // would reject a face on the user stream
+
+        let widgetFace = Self.make(kind: .face, objectIndex: 1, layer: .widget)
+        controller.handlePick(result: widgetFace)
+        #expect(controller.widgetPickResult?.kind == .face)
+        #expect(controller.pickResult == nil)
+    }
+
+    @MainActor
+    @Test("No filter set passes everything through")
+    func noFilterPassesThrough() {
+        let controller = ViewportController()
+        controller.handlePick(result: Self.make(kind: .face, objectIndex: 0))
+        #expect(controller.pickResult?.kind == .face)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.0.5] — 2026-06-05
+
+### Added
+- **Selection filter chains** (issue #33). A composable `SelectionFilter` predicate over `PickResult`, the OCCTSwiftViewport analogue of OCCT's `SelectMgr_Filter`. Lets consumers constrain what the user-geometry pick stream accepts.
+  - `SelectionFilter` is a `Sendable` wrapper over `@Sendable (PickResult) -> Bool`, exposing `matches(_:)` and `callAsFunction`. Re-exported as `_SelectionFilter`.
+  - Built-ins: `.all` / `.nothing`, `.kind(_)` / `.kinds(_)` / `.faces` / `.edges` / `.vertices`, `.layer(_)`, `.bodyIDs(_)` / `.excludingBodyIDs(_)`, `.bodyIndices(_)`.
+  - Composition: `.and(_)`, `.or(_)`, `.negated`, and chain combinators `.all(of:)` (AND) / `.any(of:)` (OR).
+  - `ViewportController.selectionFilter: SelectionFilter?` — applied in `handlePick` to the user-geometry stream. A pick that fails the filter is treated as a miss (clears `pickResult`), since GPU picking resolves a single primitive per pixel with no alternate candidate to fall through to. Widget-layer picks bypass the filter (that stream is owned by an external consumer, e.g. OCCTSwiftAIS manipulators).
+  - New `SelectionFilterTests` (13 tests). No public API break — additive (PATCH).
+  - Builds on the face/edge/vertex pick discrimination shipped in v0.55.0.
+  - Note: depth/distance filtering is intentionally absent — the GPU `PickResult` carries no depth value; use the CPU `SceneRaycast` path for distance-aware filtering.
+
 ## [0.55.2] — 2026-05-04
 
 ### Fixed


### PR DESCRIPTION
Closes #33.

Composable selection filtering over pick results — the OCCTSwiftViewport analogue of OCCT's `SelectMgr_Filter`. First of the four follow-ups spun out of the #19 Tier 3 visualization audit.

## What's added

**`SelectionFilter`** (`Sources/OCCTSwiftViewport/Picking/SelectionFilter.swift`) — a `Sendable` wrapper over `@Sendable (PickResult) -> Bool`:
- **Built-ins:** `.all` / `.nothing`, `.kind(_)` / `.kinds(_)` / `.faces` / `.edges` / `.vertices`, `.layer(_)`, `.bodyIDs(_)` / `.excludingBodyIDs(_)`, `.bodyIndices(_)`
- **Composition:** `.and(_)`, `.or(_)`, `.negated`, and chain combinators `.all(of:)` (AND) / `.any(of:)` (OR)
- `matches(_:)` + `callAsFunction`

**Integration:** `ViewportController.selectionFilter: SelectionFilter?`, applied in `handlePick` to the **user-geometry** stream only. A pick that fails the filter is treated as a miss (clears `pickResult`) — GPU picking resolves a single primitive per pixel, so there's no alternate candidate to fall through to. **Widget-layer picks bypass the filter** (that stream is owned by external consumers like OCCTSwiftAIS manipulators).

Re-exported as `_SelectionFilter`.

## Example

```swift
controller.selectionFilter = .edges.or(.vertices).and(.excludingBodyIDs(["grid"]))
```

## Notes / scope
- **Depth/distance filtering intentionally omitted** — the GPU `PickResult` carries no depth value; use the CPU `SceneRaycast` path for distance-aware filtering. Documented in code + CHANGELOG.
- No public API break — purely additive → PATCH (`v1.0.5`).
- Builds on the face/edge/vertex pick discrimination from v0.55.0.

## Tests
`SelectionFilterTests` — 13 new tests (built-ins, composition, chain combinators, and controller integration covering user-stream filtering + widget bypass). **77/77 pass** (was 64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
