### PR TITLE
feat(hud): orientation gnomon + scale bar overlays (closes #34)

### DIFF
--- a/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
@@ -80,6 +80,15 @@ public struct ViewportConfiguration: Sendable {
     /// ViewCube position.
     public var viewCubePosition: ViewCubePosition
 
+    /// Whether to show the screen-space orientation gnomon (HUD corner axes).
+    public var showOrientationGnomon: Bool
+
+    /// Whether to show the screen-space scale bar (HUD).
+    public var showScaleBar: Bool
+
+    /// Optional unit suffix shown on the scale bar (e.g. `"mm"`). Empty = number only.
+    public var scaleBarUnitLabel: String
+
     /// Whether to show coordinate axes.
     public var showAxes: Bool
 
@@ -207,7 +216,10 @@ public struct ViewportConfiguration: Sendable {
         adaptiveTessellation: Bool = true,
         enableTAA: Bool = false,
         taaBlendFactor: Float = 0.9,
-        dynamicPivotConfiguration: DynamicPivotConfiguration = .default
+        dynamicPivotConfiguration: DynamicPivotConfiguration = .default,
+        showOrientationGnomon: Bool = false,
+        showScaleBar: Bool = false,
+        scaleBarUnitLabel: String = ""
     ) {
         self.initialCameraState = initialCameraState
         self.rotationStyle = rotationStyle
@@ -244,6 +256,9 @@ public struct ViewportConfiguration: Sendable {
         self.enableTAA = enableTAA
         self.taaBlendFactor = taaBlendFactor
         self.dynamicPivotConfiguration = dynamicPivotConfiguration
+        self.showOrientationGnomon = showOrientationGnomon
+        self.showScaleBar = showScaleBar
+        self.scaleBarUnitLabel = scaleBarUnitLabel
     }
 
     // MARK: - Presets

--- a/Sources/OCCTSwiftViewport/HUD/CameraScale.swift
+++ b/Sources/OCCTSwiftViewport/HUD/CameraScale.swift
@@ -1,0 +1,95 @@
+// CameraScale.swift
+// ViewportKit
+//
+// Pure (SwiftUI-free) helpers for screen-space HUD overlays: world-units-per-point
+// from the camera, and "nice" scale-bar metrics. A Graphic3d_TransMode analogue —
+// these feed overlays that ignore the camera transform.
+
+import Foundation
+import CoreGraphics
+
+extension CameraState {
+
+    /// World units spanned by one screen point at the focus (pivot) depth.
+    ///
+    /// For orthographic cameras the value is depth-independent (`orthographicScale`
+    /// is the on-screen vertical extent). For perspective cameras it is evaluated at
+    /// `distance` — the pivot depth — since perspective scale varies with depth and
+    /// the pivot is the meaningful reference for a scale bar.
+    ///
+    /// - Parameter viewportHeightPoints: The viewport height in points (not pixels).
+    /// - Returns: World units per point, or `0` for a degenerate viewport.
+    public func worldUnitsPerPoint(viewportHeightPoints: Float) -> Float {
+        guard viewportHeightPoints > 0, viewportHeightPoints.isFinite else { return 0 }
+        let visibleHeight: Float
+        if isOrthographic {
+            visibleHeight = orthographicScale
+        } else {
+            let fovY = fieldOfView * .pi / 180.0
+            visibleHeight = 2.0 * distance * tan(fovY * 0.5)
+        }
+        return max(0, visibleHeight) / viewportHeightPoints
+    }
+}
+
+/// Resolved geometry for a screen-space scale bar.
+///
+/// Given a world-units-per-point scale and a target on-screen length, snaps the
+/// represented length to a "nice" 1 / 2 / 5 × 10ⁿ value and reports the matching
+/// bar length in points plus a formatted label.
+public struct ScaleBarMetrics: Equatable, Sendable {
+
+    /// The (rounded) world length the bar represents.
+    public let worldLength: Float
+
+    /// The bar length in screen points.
+    public let pointLength: CGFloat
+
+    /// Formatted label, e.g. `"10 mm"` (or just `"10"` when no unit is given).
+    public let label: String
+
+    /// Builds metrics for a scale bar, or `nil` if the inputs are degenerate.
+    ///
+    /// - Parameters:
+    ///   - worldUnitsPerPoint: World units per screen point (see
+    ///     `CameraState.worldUnitsPerPoint(viewportHeightPoints:)`).
+    ///   - targetPoints: The desired bar length in points; the actual length is the
+    ///     nearest nice value to this.
+    ///   - unitLabel: Optional unit suffix (the library is unit-agnostic).
+    public init?(worldUnitsPerPoint: Float, targetPoints: CGFloat, unitLabel: String = "") {
+        guard worldUnitsPerPoint > 0, worldUnitsPerPoint.isFinite,
+              targetPoints > 0 else { return nil }
+        let targetWorld = worldUnitsPerPoint * Float(targetPoints)
+        let nice = Self.niceNumber(targetWorld)
+        guard nice > 0 else { return nil }
+        self.worldLength = nice
+        self.pointLength = CGFloat(nice / worldUnitsPerPoint)
+        let num = Self.format(nice)
+        self.label = unitLabel.isEmpty ? num : "\(num) \(unitLabel)"
+    }
+
+    /// Rounds a positive value to the nearest 1 / 2 / 5 × 10ⁿ.
+    public static func niceNumber(_ x: Float) -> Float {
+        guard x > 0, x.isFinite else { return 0 }
+        let exp = floor(log10(x))
+        let base = pow(10, exp)
+        let f = x / base                 // in [1, 10)
+        let nice: Float
+        if f < 1.5 { nice = 1 }
+        else if f < 3.5 { nice = 2 }
+        else if f < 7.5 { nice = 5 }
+        else { nice = 10 }
+        return nice * base
+    }
+
+    /// Formats a nice value: integers above 1, trimmed decimals below.
+    static func format(_ x: Float) -> String {
+        if x >= 1 {
+            return String(Int(x.rounded()))
+        }
+        var s = String(format: "%.3f", x)
+        while s.hasSuffix("0") { s.removeLast() }
+        if s.hasSuffix(".") { s.removeLast() }
+        return s
+    }
+}

--- a/Sources/OCCTSwiftViewport/HUD/OrientationGnomon.swift
+++ b/Sources/OCCTSwiftViewport/HUD/OrientationGnomon.swift
@@ -1,0 +1,100 @@
+// OrientationGnomon.swift
+// ViewportKit
+//
+// Screen-space corner axes legend (X/Y/Z) that reflects camera orientation but
+// ignores camera translation — a Graphic3d_TransMode / AIS trihedron analogue.
+
+import SwiftUI
+import simd
+
+/// A small fixed-corner gnomon showing the orientation of the world X / Y / Z axes
+/// under the current camera rotation.
+///
+/// Unlike the world-space axes drawn by the renderer, this overlay stays pinned to
+/// a viewport corner and only rotates — it is a pure orientation aid (HUD), never
+/// affected by zoom or pan.
+public struct OrientationGnomon: View {
+
+    @ObservedObject private var controller: ViewportController
+
+    public init(controller: ViewportController) {
+        self.controller = controller
+    }
+
+    public var body: some View {
+        GeometryReader { geometry in
+            let size = min(geometry.size.width, geometry.size.height)
+            let center = CGPoint(x: size / 2, y: size / 2)
+            let radius = size / 2 - 9
+            let axes = Self.projectedAxes(rotation: controller.cameraState.rotation)
+
+            ZStack {
+                ForEach(axes) { axis in
+                    let tip = CGPoint(
+                        x: center.x + axis.direction.width * radius,
+                        y: center.y + axis.direction.height * radius
+                    )
+                    Path { path in
+                        path.move(to: center)
+                        path.addLine(to: tip)
+                    }
+                    .stroke(axis.color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+
+                    Text(axis.label)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(axis.color)
+                        .position(tip)
+                }
+            }
+            .frame(width: size, height: size)
+        }
+        .aspectRatio(1, contentMode: .fit)
+    }
+
+    // MARK: - Projection (pure, testable)
+
+    /// A world axis projected to gnomon screen space.
+    struct ProjectedAxis: Identifiable {
+        let label: String
+        /// Normalised screen direction (y points down, matching SwiftUI).
+        let direction: CGSize
+        let color: Color
+        /// View-space depth; larger draws on top.
+        let depth: Float
+        var id: String { label }
+    }
+
+    /// Projects the three positive world axes into gnomon screen space for a given
+    /// camera rotation, sorted back-to-front so nearer axes draw on top.
+    ///
+    /// Uses the same convention as `ViewCubeView`: transform into view space via the
+    /// inverse rotation, map +X → right and +Y → up (screen y flipped).
+    nonisolated static func projectedAxes(rotation: simd_quatf) -> [ProjectedAxis] {
+        let world: [(String, SIMD3<Float>, Color)] = [
+            ("X", SIMD3<Float>(1, 0, 0), .red),
+            ("Y", SIMD3<Float>(0, 1, 0), .green),
+            ("Z", SIMD3<Float>(0, 0, 1), .blue)
+        ]
+        return world.map { label, axis, color in
+            let v = rotation.inverse.act(axis)
+            return ProjectedAxis(
+                label: label,
+                direction: CGSize(width: CGFloat(v.x), height: CGFloat(-v.y)),
+                color: color,
+                depth: v.z
+            )
+        }
+        .sorted { $0.depth < $1.depth }
+    }
+}
+
+#if DEBUG
+struct OrientationGnomon_Previews: PreviewProvider {
+    static var previews: some View {
+        OrientationGnomon(controller: ViewportController())
+            .frame(width: 80, height: 80)
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Sources/OCCTSwiftViewport/HUD/ScaleBarView.swift
+++ b/Sources/OCCTSwiftViewport/HUD/ScaleBarView.swift
@@ -1,0 +1,81 @@
+// ScaleBarView.swift
+// ViewportKit
+//
+// Screen-space scale bar HUD: shows the world length of a fixed on-screen span at
+// the camera's focus depth. A Graphic3d_TransMode-style overlay (ignores camera).
+
+import SwiftUI
+
+/// A fixed-corner scale bar reporting the world length of a ~100-point on-screen
+/// span at the camera's focus (pivot) depth.
+///
+/// The represented length snaps to a nice 1 / 2 / 5 × 10ⁿ value via
+/// `ScaleBarMetrics`. For perspective cameras the reading is exact only at the
+/// pivot depth (scale varies with depth); for orthographic cameras it is exact
+/// everywhere.
+public struct ScaleBarView: View {
+
+    @ObservedObject private var controller: ViewportController
+
+    /// Viewport height in points — needed to convert camera scale to points.
+    private let viewportHeightPoints: CGFloat
+
+    /// Optional unit suffix shown after the number (library is unit-agnostic).
+    private let unitLabel: String
+
+    /// Target on-screen bar length in points; actual length snaps to a nice value.
+    private let targetPoints: CGFloat
+
+    public init(controller: ViewportController,
+                viewportHeightPoints: CGFloat,
+                unitLabel: String = "",
+                targetPoints: CGFloat = 100) {
+        self.controller = controller
+        self.viewportHeightPoints = viewportHeightPoints
+        self.unitLabel = unitLabel
+        self.targetPoints = targetPoints
+    }
+
+    public var body: some View {
+        let wpp = controller.cameraState.worldUnitsPerPoint(
+            viewportHeightPoints: Float(viewportHeightPoints)
+        )
+        if let metrics = ScaleBarMetrics(worldUnitsPerPoint: wpp,
+                                         targetPoints: targetPoints,
+                                         unitLabel: unitLabel) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(metrics.label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.secondary)
+                bar(length: metrics.pointLength)
+            }
+        }
+    }
+
+    /// A horizontal bar with end ticks.
+    private func bar(length: CGFloat) -> some View {
+        let tick: CGFloat = 5
+        return Path { path in
+            path.move(to: CGPoint(x: 0, y: 0))
+            path.addLine(to: CGPoint(x: 0, y: tick))
+            path.move(to: CGPoint(x: 0, y: tick / 2))
+            path.addLine(to: CGPoint(x: length, y: tick / 2))
+            path.move(to: CGPoint(x: length, y: 0))
+            path.addLine(to: CGPoint(x: length, y: tick))
+        }
+        .stroke(Color.secondary, lineWidth: 1.5)
+        .frame(width: length, height: tick)
+    }
+}
+
+#if DEBUG
+struct ScaleBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScaleBarView(controller: ViewportController(),
+                     viewportHeightPoints: 600,
+                     unitLabel: "mm")
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+++ b/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
@@ -136,3 +136,8 @@ public typealias _DynamicPivotConfiguration = DynamicPivotConfiguration
 // ViewCube
 public typealias _ViewCubeView = ViewCubeView
 public typealias _ViewCubeRegion = ViewCubeRegion
+
+// HUD overlays
+public typealias _OrientationGnomon = OrientationGnomon
+public typealias _ScaleBarView = ScaleBarView
+public typealias _ScaleBarMetrics = ScaleBarMetrics

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -89,6 +89,14 @@ public struct MetalViewportView: View {
                     viewCubeOverlay
                 }
 
+                if controller.showOrientationGnomon {
+                    orientationGnomonOverlay
+                }
+
+                if controller.showScaleBar {
+                    scaleBarOverlay(viewportSize: geometry.size)
+                }
+
                 if !controller.measurements.isEmpty {
                     measurementOverlay(viewportSize: geometry.size)
                 }
@@ -396,6 +404,37 @@ public struct MetalViewportView: View {
                 ViewCubeView(controller: controller)
                     .frame(width: 80, height: 80)
                     .padding(12)
+            }
+        }
+    }
+
+    // MARK: - HUD Overlays
+
+    /// Orientation gnomon pinned to the top-leading corner.
+    private var orientationGnomonOverlay: some View {
+        VStack {
+            HStack {
+                OrientationGnomon(controller: controller)
+                    .frame(width: 64, height: 64)
+                    .padding(12)
+                Spacer()
+            }
+            Spacer()
+        }
+    }
+
+    /// Scale bar pinned to the bottom-leading corner.
+    private func scaleBarOverlay(viewportSize: CGSize) -> some View {
+        VStack {
+            Spacer()
+            HStack {
+                ScaleBarView(
+                    controller: controller,
+                    viewportHeightPoints: viewportSize.height,
+                    unitLabel: controller.configuration.scaleBarUnitLabel
+                )
+                .padding(12)
+                Spacer()
             }
         }
     }

--- a/Sources/OCCTSwiftViewport/Views/ViewportController.swift
+++ b/Sources/OCCTSwiftViewport/Views/ViewportController.swift
@@ -48,6 +48,12 @@ public final class ViewportController: ObservableObject {
     /// Whether the grid is visible.
     @Published public var showGrid: Bool
 
+    /// Whether the screen-space orientation gnomon (HUD corner axes) is visible.
+    @Published public var showOrientationGnomon: Bool
+
+    /// Whether the screen-space scale bar (HUD) is visible.
+    @Published public var showScaleBar: Bool
+
     /// Whether an animation is in progress.
     @Published public private(set) var isAnimating: Bool = false
 
@@ -147,6 +153,8 @@ public final class ViewportController: ObservableObject {
         self.showViewCube = configuration.showViewCube
         self.showAxes = configuration.showAxes
         self.showGrid = configuration.showGrid
+        self.showOrientationGnomon = configuration.showOrientationGnomon
+        self.showScaleBar = configuration.showScaleBar
         self.lightingConfiguration = configuration.lightingConfiguration
         self.enableDepthOfField = configuration.enableDepthOfField
         self.dofAperture = configuration.dofAperture

--- a/Tests/OCCTSwiftViewportTests/HUDOverlayTests.swift
+++ b/Tests/OCCTSwiftViewportTests/HUDOverlayTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@Suite("HUD overlay logic")
+struct HUDOverlayTests {
+
+    // MARK: - CameraState.worldUnitsPerPoint
+
+    @Test("Orthographic scale is depth-independent and divides by viewport height")
+    func orthographicScale() {
+        var cs = CameraState()
+        cs.isOrthographic = true
+        cs.orthographicScale = 20  // 20 world units span the full height
+        // 20 units over 100 points → 0.2 units/point
+        #expect(abs(cs.worldUnitsPerPoint(viewportHeightPoints: 100) - 0.2) < 1e-6)
+        // Distance must not matter in ortho.
+        cs.distance = 999
+        #expect(abs(cs.worldUnitsPerPoint(viewportHeightPoints: 100) - 0.2) < 1e-6)
+    }
+
+    @Test("Perspective scale uses 2*distance*tan(fov/2) over height")
+    func perspectiveScale() {
+        var cs = CameraState()
+        cs.isOrthographic = false
+        cs.fieldOfView = 90      // tan(45°) = 1
+        cs.distance = 10         // visible height = 2 * 10 * 1 = 20
+        let wpp = cs.worldUnitsPerPoint(viewportHeightPoints: 200)
+        #expect(abs(wpp - (20.0 / 200.0)) < 1e-5)  // 0.1
+    }
+
+    @Test("Degenerate viewport height yields zero")
+    func degenerateHeight() {
+        let cs = CameraState()
+        #expect(cs.worldUnitsPerPoint(viewportHeightPoints: 0) == 0)
+        #expect(cs.worldUnitsPerPoint(viewportHeightPoints: -5) == 0)
+    }
+
+    // MARK: - ScaleBarMetrics.niceNumber
+
+    @Test("niceNumber snaps to 1/2/5 x 10^n")
+    func niceNumbers() {
+        #expect(ScaleBarMetrics.niceNumber(1.0) == 1)
+        #expect(ScaleBarMetrics.niceNumber(1.2) == 1)
+        #expect(ScaleBarMetrics.niceNumber(1.6) == 2)
+        #expect(ScaleBarMetrics.niceNumber(3.0) == 2)
+        #expect(ScaleBarMetrics.niceNumber(4.0) == 5)
+        #expect(ScaleBarMetrics.niceNumber(8.0) == 10)
+        #expect(ScaleBarMetrics.niceNumber(40.0) == 50)
+        #expect(ScaleBarMetrics.niceNumber(230.0) == 200)
+        #expect(abs(ScaleBarMetrics.niceNumber(0.04) - 0.05) < 1e-6)
+    }
+
+    @Test("niceNumber rejects non-positive / non-finite")
+    func niceNumberGuards() {
+        #expect(ScaleBarMetrics.niceNumber(0) == 0)
+        #expect(ScaleBarMetrics.niceNumber(-3) == 0)
+        #expect(ScaleBarMetrics.niceNumber(.nan) == 0)
+        #expect(ScaleBarMetrics.niceNumber(.infinity) == 0)
+    }
+
+    // MARK: - ScaleBarMetrics
+
+    @Test("Metrics snap world length and recompute point length")
+    func metrics() {
+        // 0.1 units/point, target 100 points → target world 10 → nice 10.
+        let m = ScaleBarMetrics(worldUnitsPerPoint: 0.1, targetPoints: 100)
+        #expect(m != nil)
+        #expect(m?.worldLength == 10)
+        // 10 world / 0.1 per point = 100 points exactly.
+        #expect(abs((m?.pointLength ?? 0) - 100) < 1e-6)
+        #expect(m?.label == "10")
+    }
+
+    @Test("Unit label is appended; sub-unit lengths format with trimmed decimals")
+    func labelFormatting() {
+        // 0.004 units/point, target 100 → target world 0.4 → nice 0.5.
+        let m = ScaleBarMetrics(worldUnitsPerPoint: 0.004, targetPoints: 100, unitLabel: "mm")
+        #expect(m?.worldLength == 0.5)
+        #expect(m?.label == "0.5 mm")
+    }
+
+    @Test("Metrics reject degenerate scale")
+    func metricsGuards() {
+        #expect(ScaleBarMetrics(worldUnitsPerPoint: 0, targetPoints: 100) == nil)
+        #expect(ScaleBarMetrics(worldUnitsPerPoint: .nan, targetPoints: 100) == nil)
+        #expect(ScaleBarMetrics(worldUnitsPerPoint: 0.1, targetPoints: 0) == nil)
+    }
+
+    // MARK: - OrientationGnomon projection
+
+    @Test("Identity rotation maps +X right, +Y up (screen y flipped), +Z toward viewer")
+    func gnomonIdentity() {
+        let axes = OrientationGnomon.projectedAxes(rotation: simd_quatf(angle: 0, axis: SIMD3<Float>(0, 0, 1)))
+        let byLabel = Dictionary(uniqueKeysWithValues: axes.map { ($0.label, $0) })
+        #expect(abs((byLabel["X"]?.direction.width ?? 0) - 1) < 1e-5)
+        #expect(abs(byLabel["X"]?.direction.height ?? 9) < 1e-5)
+        // +Y world is up → screen y negative.
+        #expect(abs((byLabel["Y"]?.direction.height ?? 0) - (-1)) < 1e-5)
+        #expect(abs(byLabel["Y"]?.direction.width ?? 9) < 1e-5)
+        #expect(axes.count == 3)
+    }
+
+    @Test("Axes are sorted back-to-front by depth")
+    func gnomonDepthSorted() {
+        // A tilted rotation so the three depths differ.
+        let q = simd_quatf(angle: 0.7, axis: simd_normalize(SIMD3<Float>(1, 1, 0)))
+        let axes = OrientationGnomon.projectedAxes(rotation: q)
+        for i in 1..<axes.count {
+            #expect(axes[i - 1].depth <= axes[i].depth)
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.0.6] — 2026-06-05
+
+### Added
+- **Screen-space HUD overlays** (issue #34) — the `Graphic3d_TransMode` analogue: orientation-only overlays pinned to viewport corners, distinct from the world-space axes/grid. Implemented as SwiftUI overlays (the ViewCube pattern), no extra Metal pass.
+  - **`OrientationGnomon`** — top-leading corner gnomon drawing the world X/Y/Z axes (red/green/blue) under the current camera rotation; back-to-front depth sorted. Re-exported as `_OrientationGnomon`.
+  - **`ScaleBarView`** — bottom-leading scale bar reporting the world length of a ~100-point span at the camera's focus (pivot) depth. Re-exported as `_ScaleBarView`.
+  - **`CameraState.worldUnitsPerPoint(viewportHeightPoints:)`** — unified perspective (`2·distance·tan(fov/2)`) + orthographic (`orthographicScale`) world-units-per-point.
+  - **`ScaleBarMetrics`** — snaps the represented length to a nice 1/2/5×10ⁿ value, recomputes the bar's point length, and formats an optional unit label. Re-exported as `_ScaleBarMetrics`.
+  - **Config:** `ViewportConfiguration.showOrientationGnomon` / `showScaleBar` / `scaleBarUnitLabel` (all default off / empty → source-compatible), mirrored by `ViewportController.showOrientationGnomon` / `showScaleBar` published toggles.
+  - New `HUDOverlayTests` (10 tests → 87 total, all green). Additive, no API break (PATCH).
+  - Note: for perspective cameras the scale bar is exact only at the pivot depth (scale varies with depth); orthographic is exact everywhere.
+
 ## [1.0.5] — 2026-06-05
 
 ### Added


### PR DESCRIPTION
Closes #34.

Screen-space HUD overlays — the `Graphic3d_TransMode` analogue: orientation-only overlays pinned to viewport corners that ignore camera **translation** (zoom/pan), distinct from the world-space axes and grid. Second of the four follow-ups from the #19 Tier 3 audit.

Implemented as SwiftUI overlays (the existing ViewCube pattern) — **no extra Metal pass**.

## What's added

- **`OrientationGnomon`** — top-leading corner gnomon drawing world X/Y/Z axes (red/green/blue) under the current camera rotation, back-to-front depth sorted. Uses the same projection convention as `ViewCubeView`. → `_OrientationGnomon`
- **`ScaleBarView`** — bottom-leading scale bar reporting the world length of a ~100-point on-screen span at the camera's focus (pivot) depth, with end ticks + label. → `_ScaleBarView`
- **`CameraState.worldUnitsPerPoint(viewportHeightPoints:)`** — unified perspective (`2·distance·tan(fov/2)`) + orthographic (`orthographicScale`) world-units-per-point. Pure/headless.
- **`ScaleBarMetrics`** — snaps the represented length to a nice `1/2/5×10ⁿ` value, recomputes the bar's point length, formats an optional unit label. Pure/headless. → `_ScaleBarMetrics`

## Config

`ViewportConfiguration.showOrientationGnomon` / `showScaleBar` / `scaleBarUnitLabel` (all default **off** / empty → source-compatible), mirrored by `ViewportController.showOrientationGnomon` / `showScaleBar` published toggles.

## Notes / scope
- Perspective scale bar is exact only at the **pivot depth** (perspective scale varies with depth); orthographic is exact everywhere. Documented in code + CHANGELOG.
- No public API break — purely additive → PATCH (`v1.0.6`).

## Tests
`HUDOverlayTests` — 10 new tests covering `worldUnitsPerPoint` (persp/ortho/degenerate), `niceNumber` snapping + guards, `ScaleBarMetrics` formatting, and gnomon axis projection (identity mapping + depth sort). **87/87 pass** (was 77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
