### PR TITLE
feat(input): portable modifier-key interpretation seam (advances #35)

### DIFF
--- a/Sources/OCCTSwiftViewport/Configuration/GestureConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/GestureConfiguration.swift
@@ -136,6 +136,22 @@ public struct GestureConfiguration: Sendable {
         optionDrag: .pan,
         commandDrag: .zoom
     )
+
+    // MARK: - Input Interpretation
+
+    /// Resolves the action for a pointer drag given the active modifier keys.
+    ///
+    /// Priority — matching the historical macOS handler — is
+    /// command → shift → option → unmodified. This is the portable interpretation
+    /// seam: platform code bridges its native modifier flags into
+    /// `ViewportModifierKeys` (see its `init(_:)` overloads) and calls this, so the
+    /// mapping stays free of `NSEvent` / `UIEvent`.
+    public func dragAction(for modifiers: ViewportModifierKeys) -> GestureAction {
+        if modifiers.contains(.command) { return commandDrag }
+        if modifiers.contains(.shift) { return shiftDrag }
+        if modifiers.contains(.option) { return optionDrag }
+        return mouseDrag
+    }
 }
 
 // MARK: - Gesture Action

--- a/Sources/OCCTSwiftViewport/Input/ViewportModifierKeys.swift
+++ b/Sources/OCCTSwiftViewport/Input/ViewportModifierKeys.swift
@@ -1,0 +1,72 @@
+// ViewportModifierKeys.swift
+// ViewportKit
+//
+// Platform-neutral keyboard-modifier abstraction for input interpretation —
+// an Aspect_VKey analogue.
+
+import Foundation
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// Platform-neutral keyboard-modifier state used to interpret viewport input.
+///
+/// This is the OCCTSwiftViewport analogue of OCCT's `Aspect_VKeyFlags`: it
+/// decouples gesture interpretation from `NSEvent.ModifierFlags` (AppKit) and
+/// `UIKeyModifierFlags` (UIKit) so the same mapping logic can be driven by any
+/// input source — AppKit, UIKit, or (future) visionOS / synthetic input.
+///
+/// Bridge from a platform type with the `init(_:)` overloads, then resolve an
+/// action via `GestureConfiguration.dragAction(for:)`.
+public struct ViewportModifierKeys: OptionSet, Sendable, Hashable {
+
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /// Shift key.
+    public static let shift = ViewportModifierKeys(rawValue: 1 << 0)
+
+    /// Control key.
+    public static let control = ViewportModifierKeys(rawValue: 1 << 1)
+
+    /// Option / Alt key.
+    public static let option = ViewportModifierKeys(rawValue: 1 << 2)
+
+    /// Command / Meta key.
+    public static let command = ViewportModifierKeys(rawValue: 1 << 3)
+}
+
+#if canImport(AppKit)
+extension ViewportModifierKeys {
+
+    /// Bridges AppKit modifier flags into the portable representation.
+    public init(_ flags: NSEvent.ModifierFlags) {
+        var keys: ViewportModifierKeys = []
+        if flags.contains(.shift) { keys.insert(.shift) }
+        if flags.contains(.control) { keys.insert(.control) }
+        if flags.contains(.option) { keys.insert(.option) }
+        if flags.contains(.command) { keys.insert(.command) }
+        self = keys
+    }
+}
+#endif
+
+#if canImport(UIKit)
+import UIKit
+
+extension ViewportModifierKeys {
+
+    /// Bridges UIKit key-modifier flags into the portable representation.
+    public init(_ flags: UIKeyModifierFlags) {
+        var keys: ViewportModifierKeys = []
+        if flags.contains(.shift) { keys.insert(.shift) }
+        if flags.contains(.control) { keys.insert(.control) }
+        if flags.contains(.alternate) { keys.insert(.option) }
+        if flags.contains(.command) { keys.insert(.command) }
+        self = keys
+    }
+}
+#endif

--- a/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+++ b/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
@@ -96,6 +96,7 @@ public typealias _OrthoBounds = OrthoBounds
 public typealias _ViewportConfiguration = ViewportConfiguration
 public typealias _GestureConfiguration = GestureConfiguration
 public typealias _GestureAction = GestureAction
+public typealias _ViewportModifierKeys = ViewportModifierKeys
 public typealias _ViewCubePosition = ViewCubePosition
 public typealias _ClipPlane = ClipPlane
 public typealias _RenderingQuality = RenderingQuality

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -319,20 +319,9 @@ public struct MetalViewportView: View {
                 )
                 lastDragValue = value.translation
 
-                let modifiers = NSApp.currentEvent?.modifierFlags ?? []
+                let modifiers = ViewportModifierKeys(NSApp.currentEvent?.modifierFlags ?? [])
                 let gc = controller.configuration.gestureConfiguration
-                print("[GESTURE] mouseDrag=\(gc.mouseDrag) shift=\(modifiers.contains(.shift))")
-
-                let action: GestureAction
-                if modifiers.contains(.command) {
-                    action = gc.commandDrag
-                } else if modifiers.contains(.shift) {
-                    action = gc.shiftDrag
-                } else if modifiers.contains(.option) {
-                    action = gc.optionDrag
-                } else {
-                    action = gc.mouseDrag
-                }
+                let action = gc.dragAction(for: modifiers)
 
                 switch action {
                 case .pan:

--- a/Tests/OCCTSwiftViewportTests/InputAbstractionTests.swift
+++ b/Tests/OCCTSwiftViewportTests/InputAbstractionTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import OCCTSwiftViewport
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+@Suite("Input abstraction")
+struct InputAbstractionTests {
+
+    // MARK: - ViewportModifierKeys
+
+    @Test("OptionSet membership is independent per modifier")
+    func optionSetMembership() {
+        let combo: ViewportModifierKeys = [.command, .shift]
+        #expect(combo.contains(.command))
+        #expect(combo.contains(.shift))
+        #expect(!combo.contains(.option))
+        #expect(!combo.contains(.control))
+        #expect(ViewportModifierKeys().isEmpty)
+    }
+
+    // MARK: - dragAction priority
+
+    @Test("Default config: unmodified=orbit, shift=pan, option=zoom, command=select")
+    func defaultMapping() {
+        let gc = GestureConfiguration.default
+        #expect(gc.dragAction(for: []) == .orbit)
+        #expect(gc.dragAction(for: .shift) == .pan)
+        #expect(gc.dragAction(for: .option) == .zoom)
+        #expect(gc.dragAction(for: .command) == .select)
+    }
+
+    @Test("Command wins over shift wins over option (historical priority)")
+    func priorityOrder() {
+        let gc = GestureConfiguration.default
+        // command beats everything
+        #expect(gc.dragAction(for: [.command, .shift, .option]) == gc.commandDrag)
+        // shift beats option when no command
+        #expect(gc.dragAction(for: [.shift, .option]) == gc.shiftDrag)
+        // option only when alone
+        #expect(gc.dragAction(for: .option) == gc.optionDrag)
+    }
+
+    @Test("Control alone falls through to the unmodified action")
+    func controlFallsThrough() {
+        let gc = GestureConfiguration.default
+        #expect(gc.dragAction(for: .control) == gc.mouseDrag)
+    }
+
+    @Test("Blender and Fusion360 presets resolve through the same seam")
+    func presetMappings() {
+        let blender = GestureConfiguration.blender
+        #expect(blender.dragAction(for: []) == .select)
+        #expect(blender.dragAction(for: .option) == .orbit)
+
+        let fusion = GestureConfiguration.fusion360
+        #expect(fusion.dragAction(for: .shift) == .orbit)
+        #expect(fusion.dragAction(for: .command) == .zoom)
+    }
+
+    // MARK: - Platform bridge
+
+    #if canImport(AppKit)
+    @Test("AppKit modifier flags bridge into ViewportModifierKeys")
+    func appKitBridge() {
+        #expect(ViewportModifierKeys(NSEvent.ModifierFlags.command).contains(.command))
+        #expect(ViewportModifierKeys(NSEvent.ModifierFlags([.shift, .option])) == [.shift, .option])
+        #expect(ViewportModifierKeys(NSEvent.ModifierFlags()).isEmpty)
+    }
+
+    @Test("Bridged flags resolve identically to native modifiers")
+    func bridgeResolvesSameAction() {
+        let gc = GestureConfiguration.default
+        let bridged = ViewportModifierKeys(NSEvent.ModifierFlags.shift)
+        #expect(gc.dragAction(for: bridged) == gc.shiftDrag)
+    }
+    #endif
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.0.7] — 2026-06-05
+
+### Added
+- **Portable input-interpretation seam** (issue #35, first increment) — an `Aspect_VKey` analogue decoupling gesture interpretation from `NSEvent` / `UIEvent`.
+  - **`ViewportModifierKeys`** — a `Sendable` `OptionSet` (`.shift` / `.control` / `.option` / `.command`) with bridging initialisers from `NSEvent.ModifierFlags` (AppKit) and `UIKeyModifierFlags` (UIKit). Re-exported as `_ViewportModifierKeys`.
+  - **`GestureConfiguration.dragAction(for:)`** — resolves a drag's `GestureAction` from modifier keys, preserving the historical priority (command → shift → option → unmodified).
+  - The macOS drag handler now bridges native flags into `ViewportModifierKeys` and calls the resolver instead of branching on `NSEvent` inline; a stray debug `print` was removed. Behaviour is unchanged.
+  - New `InputAbstractionTests` (7 tests → 94 total, all green).
+
+### Note
+- This is the modifier/key portion of #35. A full portable pointer/scroll/pinch event model remains; #35 stays open to track it. This seam is the foundation the visionOS work (#36) builds on.
+
 ## [1.0.6] — 2026-06-05
 
 ### Added


### PR DESCRIPTION
Advances #35 (does **not** close it — see "Remaining" below).

First increment of the input-abstraction layer: an `Aspect_VKey` analogue that decouples gesture **interpretation** from `NSEvent` / `UIEvent`. This is the genuinely portable seam — and the one #36 (visionOS) needs.

## What's added

- **`ViewportModifierKeys`** — a `Sendable` `OptionSet` (`.shift` / `.control` / `.option` / `.command`) with bridging initialisers from `NSEvent.ModifierFlags` (AppKit) and `UIKeyModifierFlags` (UIKit). → `_ViewportModifierKeys`
- **`GestureConfiguration.dragAction(for:)`** — resolves a drag's `GestureAction` from modifier keys, preserving the historical priority **command → shift → option → unmodified**.

## What changed
- The macOS drag handler now bridges native flags into `ViewportModifierKeys` and calls `dragAction(for:)` instead of branching on `NSEvent` inline. **Behaviour is unchanged** (same priority, same actions).
- Removed a stray `print("[GESTURE] …")` debug line that was firing on every drag frame.

## Remaining for #35 (issue stays open)
- A full portable pointer/scroll/pinch event model (`ViewportInputEvent`: down/move/up, scroll, pinch, rotate) that the platform representables translate into, so the camera/pick interpretation never sees `NSEvent` / `UIGestureRecognizer` at all. That part reroutes the iOS gesture pipeline and needs on-device verification, so it's deferred to a follow-up.

## Tests
`InputAbstractionTests` — 7 new tests: OptionSet semantics, resolver priority across default/blender/fusion360 presets, control-falls-through, and the AppKit bridge. **94/94 pass** (was 87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
