### PR TITLE
feat(input): portable ViewportInputEvent model + dispatch router (closes #35)

### DIFF
--- a/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/InputInspector.swift
+++ b/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/InputInspector.swift
@@ -1,0 +1,110 @@
+// InputInspector.swift
+// Demo-only HUD that visualizes the viewport's portable ViewportInputEvent stream,
+// so gesture interpretation can be verified live on device (issue #35).
+
+import SwiftUI
+import OCCTSwiftViewport
+
+/// Rolling log of recent input events, fed from `ViewportController.onInputEvent`.
+@MainActor
+final class InputEventLog: ObservableObject {
+
+    struct Entry: Identifiable {
+        let id: Int
+        let text: String
+    }
+
+    @Published private(set) var entries: [Entry] = []
+
+    private var counter = 0
+    private let maxEntries = 14
+
+    func record(_ event: _ViewportInputEvent) {
+        counter += 1
+        entries.append(Entry(id: counter, text: Self.describe(event)))
+        if entries.count > maxEntries {
+            entries.removeFirst(entries.count - maxEntries)
+        }
+    }
+
+    func clear() {
+        entries.removeAll()
+    }
+
+    private static func f(_ v: Float) -> String { String(format: "%.1f", v) }
+
+    private static func describe(_ event: _ViewportInputEvent) -> String {
+        switch event {
+        case let .dragChanged(delta, modifiers):
+            return "drag Δ(\(f(delta.x)), \(f(delta.y)))\(mods(modifiers))"
+        case let .dragEnded(velocity, modifiers):
+            return "drag end v(\(f(velocity.x)), \(f(velocity.y)))\(mods(modifiers))"
+        case let .twoFingerPanChanged(t):
+            return "2-finger pan (\(f(t.x)), \(f(t.y)))"
+        case let .twoFingerPanEnded(v):
+            return "2-finger pan end v(\(f(v.x)), \(f(v.y)))"
+        case let .pinchChanged(scale):
+            return "pinch ×\(String(format: "%.3f", scale))"
+        case .pinchEnded:
+            return "pinch end"
+        case let .rotateChanged(radians):
+            return "rotate \(f(radians * 180 / .pi))°"
+        case .rotateEnded:
+            return "rotate end"
+        case let .scroll(delta, cursor, _):
+            return "scroll \(f(delta)) @(\(f(cursor.x)), \(f(cursor.y)))"
+        case let .tap(_, count):
+            return count >= 2 ? "double-tap → reset" : "tap"
+        @unknown default:
+            return "event"
+        }
+    }
+
+    private static func mods(_ m: _ViewportModifierKeys) -> String {
+        var s = ""
+        if m.contains(.shift) { s += "⇧" }
+        if m.contains(.control) { s += "⌃" }
+        if m.contains(.option) { s += "⌥" }
+        if m.contains(.command) { s += "⌘" }
+        return s.isEmpty ? "" : " [\(s)]"
+    }
+}
+
+/// Translucent panel listing the most recent input events (newest at the bottom).
+struct InputInspectorView: View {
+
+    @ObservedObject var log: InputEventLog
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Input events")
+                    .font(.caption.weight(.semibold))
+                Spacer()
+                Button {
+                    log.clear()
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain)
+                .font(.caption2)
+            }
+            .padding(.bottom, 2)
+
+            if log.entries.isEmpty {
+                Text("Interact with the viewport…")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(log.entries) { entry in
+                    Text(entry.text)
+                        .font(.system(.caption2, design: .monospaced))
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(10)
+        .frame(width: 230, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -94,6 +94,10 @@ struct SpikeView: View {
 
     @StateObject private var materialLibrary = MaterialLibrary()
 
+    // Input-event inspector (issue #35 on-device verification).
+    @StateObject private var inputLog = InputEventLog()
+    @State private var showInputInspector = false
+
     var body: some View {
         viewportLayout
         .onAppear {
@@ -107,6 +111,11 @@ struct SpikeView: View {
             }
             // Build procedural metadata for primitive face selection
             buildProceduralMetadata()
+
+            // Feed the input-event inspector (issue #35).
+            controller.onInputEvent = { [inputLog] event in
+                inputLog.record(event)
+            }
 
             // --test-all-demos is now handled in AppEntry.runHeadless before
             // SwiftUI boots — no need for a duplicate trigger here.
@@ -150,10 +159,12 @@ struct SpikeView: View {
             sidebar
         } detail: {
             MetalViewportView(controller: controller, bodies: $bodies)
+                .overlay(alignment: .topTrailing) { inputInspectorOverlay }
                 .overlay(alignment: .bottom) { statusOverlay }
         }
         #else
         MetalViewportView(controller: controller, bodies: $bodies)
+            .overlay(alignment: .topTrailing) { inputInspectorOverlay }
             .overlay(alignment: .topLeading) {
                 Button {
                     showSettings = true
@@ -182,6 +193,14 @@ struct SpikeView: View {
     }
 
     @ViewBuilder
+    private var inputInspectorOverlay: some View {
+        if showInputInspector {
+            InputInspectorView(log: inputLog)
+                .padding(12)
+        }
+    }
+
+    @ViewBuilder
     private var statusOverlay: some View {
         if let status = operationStatus {
             Text(status)
@@ -197,6 +216,11 @@ struct SpikeView: View {
 
     private var sidebar: some View {
         List {
+            DisclosureGroup("Debug") {
+                Toggle("Input event inspector", isOn: $showInputInspector)
+                    .accessibilityIdentifier("inputInspectorToggle")
+            }
+
             DisclosureGroup("File & Tools") {
                 fileSection
                 exportSection

--- a/Sources/OCCTSwiftViewport/Input/ViewportInputEvent.swift
+++ b/Sources/OCCTSwiftViewport/Input/ViewportInputEvent.swift
@@ -1,0 +1,52 @@
+// ViewportInputEvent.swift
+// ViewportKit
+//
+// Portable, source-neutral input event model — an Aspect_Touch / Aspect_VKey
+// analogue. Platform layers translate native input into these; the viewport
+// interprets them via ViewportController.dispatch(_:). Synthetic / XR / test
+// input can produce the same events without any AppKit / UIKit type.
+
+import simd
+
+/// A platform-neutral viewport input event.
+///
+/// Deltas and velocities are raw (in points / points-per-second); the *meaning*
+/// (which gesture action, sign conventions, zoom curve) is applied centrally by
+/// `ViewportController.dispatch(_:)`, never by the platform translation layer.
+///
+/// This is the seam that lets non-AppKit/UIKit input sources — visionOS / XR,
+/// Catalyst, scripting, tests — drive the camera through one entry point.
+public enum ViewportInputEvent: Sendable, Equatable {
+
+    /// Primary pointer drag changed (mouse on macOS, single finger on iOS).
+    /// `modifiers` is empty on iOS.
+    case dragChanged(delta: SIMD2<Float>, modifiers: ViewportModifierKeys)
+
+    /// Primary pointer drag ended, carrying release velocity for inertia.
+    case dragEnded(velocity: SIMD2<Float>, modifiers: ViewportModifierKeys)
+
+    /// Secondary translation changed (two-finger pan on iOS).
+    case twoFingerPanChanged(translation: SIMD2<Float>)
+
+    /// Secondary translation ended, carrying release velocity.
+    case twoFingerPanEnded(velocity: SIMD2<Float>)
+
+    /// Pinch changed, as an incremental scale ratio (1.0 = no change).
+    case pinchChanged(scale: Float)
+
+    /// Pinch ended.
+    case pinchEnded
+
+    /// Rotate changed, as an incremental angle in radians.
+    case rotateChanged(radians: Float)
+
+    /// Rotate ended.
+    case rotateEnded
+
+    /// Scroll-wheel input toward a cursor position (macOS).
+    case scroll(delta: Float, cursorNDC: SIMD2<Float>, aspectRatio: Float)
+
+    /// A tap / click at normalized-device coordinates. `count >= 2` resets the view;
+    /// single taps are observational here (picking runs on its own renderer-bound path).
+    case tap(ndc: SIMD2<Float>, count: Int)
+}

--- a/Sources/OCCTSwiftViewport/Input/ViewportInputRouter.swift
+++ b/Sources/OCCTSwiftViewport/Input/ViewportInputRouter.swift
@@ -1,0 +1,108 @@
+// ViewportInputRouter.swift
+// ViewportKit
+//
+// Central interpretation of ViewportInputEvent into camera actions. This is the
+// single entry point platform layers (and synthetic / XR / test input) feed; it
+// owns gesture-action resolution, sign conventions, and the zoom curve so the
+// translation layer stays a thin native->event adapter.
+
+import Foundation
+import simd
+
+extension ViewportController {
+
+    /// Interprets a portable input event and applies it to the camera.
+    ///
+    /// The platform layer is responsible only for translating native input into
+    /// `ViewportInputEvent` (delta math, gesture arbitration) and for any lifecycle
+    /// glue it already owns (e.g. dynamic-pivot scheduling). All *interpretation* —
+    /// which `GestureAction` a drag maps to, the orbit X-axis inversion, the
+    /// drag-to-zoom curve — lives here, so the meaning is identical regardless of
+    /// the input source.
+    public func dispatch(_ event: ViewportInputEvent) {
+        onInputEvent?(event)
+
+        switch event {
+        case let .dragChanged(delta, modifiers):
+            apply(dragDelta: delta, modifiers: modifiers)
+
+        case let .dragEnded(velocity, _):
+            endDrag(velocity: velocity)
+
+        case let .twoFingerPanChanged(translation):
+            handlePan(translation: CGSize(width: CGFloat(translation.x),
+                                          height: CGFloat(translation.y)))
+
+        case let .twoFingerPanEnded(velocity):
+            endPan(velocity: CGSize(width: CGFloat(velocity.x),
+                                    height: CGFloat(velocity.y)))
+
+        case let .pinchChanged(scale):
+            handleZoom(magnification: CGFloat(scale))
+
+        case .pinchEnded:
+            break
+
+        case let .rotateChanged(radians):
+            handleRoll(angle: CGFloat(radians))
+
+        case .rotateEnded:
+            break
+
+        case let .scroll(delta, cursorNDC, aspectRatio):
+            handleScrollZoom(delta: CGFloat(delta),
+                             cursorNormalized: cursorNDC,
+                             aspectRatio: aspectRatio)
+
+        case let .tap(_, count):
+            if count >= 2 { reset(animated: true) }
+        }
+    }
+
+    // MARK: - Drag interpretation
+
+    /// Resolves the action for a primary drag. macOS uses modifier-aware
+    /// `dragAction(for:)`; iOS (no modifiers) uses `singleFingerDrag`.
+    private func resolvedDragAction(_ modifiers: ViewportModifierKeys) -> GestureAction {
+        #if os(macOS)
+        return configuration.gestureConfiguration.dragAction(for: modifiers)
+        #else
+        return configuration.gestureConfiguration.singleFingerDrag
+        #endif
+    }
+
+    private func apply(dragDelta delta: SIMD2<Float>, modifiers: ViewportModifierKeys) {
+        switch resolvedDragAction(modifiers) {
+        case .orbit:
+            activeInputDragMode = .orbit
+            // Negate X so left/right drag rotates the model under the pointer.
+            handleOrbit(translation: CGSize(width: CGFloat(-delta.x),
+                                            height: CGFloat(delta.y)))
+        case .pan:
+            activeInputDragMode = .pan
+            handlePan(translation: CGSize(width: CGFloat(delta.x),
+                                          height: CGFloat(delta.y)))
+        case .zoom:
+            activeInputDragMode = .zoom
+            handleZoom(magnification: CGFloat(1.0 + delta.y * 0.02))
+        default:
+            // .select / .focusOnPoint / .resetView / .none don't drive a drag;
+            // leave activeInputDragMode unchanged (matches the historical handler).
+            break
+        }
+    }
+
+    private func endDrag(velocity: SIMD2<Float>) {
+        switch activeInputDragMode {
+        case .orbit:
+            endOrbit(velocity: CGSize(width: CGFloat(-velocity.x),
+                                      height: CGFloat(velocity.y)))
+        case .pan:
+            endPan(velocity: CGSize(width: CGFloat(velocity.x),
+                                    height: CGFloat(velocity.y)))
+        case .zoom:
+            break
+        }
+        activeInputDragMode = .orbit
+    }
+}

--- a/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+++ b/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
@@ -97,6 +97,7 @@ public typealias _ViewportConfiguration = ViewportConfiguration
 public typealias _GestureConfiguration = GestureConfiguration
 public typealias _GestureAction = GestureAction
 public typealias _ViewportModifierKeys = ViewportModifierKeys
+public typealias _ViewportInputEvent = ViewportInputEvent
 public typealias _ViewCubePosition = ViewCubePosition
 public typealias _ClipPlane = ClipPlane
 public typealias _RenderingQuality = RenderingQuality

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -39,17 +39,13 @@ public struct MetalViewportView: View {
 
     // MARK: - Gesture State
 
+    // These hold per-frame deltas for translating native gestures into
+    // `ViewportInputEvent`s; interpretation (which action a drag performs) lives
+    // in `ViewportController.dispatch(_:)`.
     @State private var lastDragValue: CGSize = .zero
     @State private var lastMagnification: CGFloat = 1.0
     @State private var isPanning: Bool = false
     @State private var lastRotation: Angle = .zero
-
-    #if os(macOS)
-    /// Tracks which modifier-based gesture the current drag is performing.
-    @State private var activeDragMode: MacDragMode = .orbit
-
-    private enum MacDragMode { case orbit, pan, zoom }
-    #endif
 
     // MARK: - Initialization
 
@@ -184,6 +180,10 @@ public struct MetalViewportView: View {
         #endif
         let ndc = SIMD2<Float>(ndcX, ndcY)
 
+        // Observational only — routes nothing for a single tap, but surfaces taps
+        // on the input-event stream (e.g. for a HUD input inspector).
+        controller.dispatch(.tap(ndc: ndc, count: 1))
+
         let ctrl = controller
         renderer?.performPick(at: pixel) { result in
             Task { @MainActor in
@@ -205,11 +205,11 @@ public struct MetalViewportView: View {
                         let nx = Float((cursorInView.x / viewSize.width) * 2 - 1)
                         let ny = Float((1 - cursorInView.y / viewSize.height) * 2 - 1)
                         let aspect = Float(viewSize.width / viewSize.height)
-                        controller.handleScrollZoom(
-                            delta: delta,
-                            cursorNormalized: SIMD2<Float>(nx, ny),
+                        controller.dispatch(.scroll(
+                            delta: Float(delta),
+                            cursorNDC: SIMD2<Float>(nx, ny),
                             aspectRatio: aspect
-                        )
+                        ))
                         controller.scheduleDynamicPivotUpdate(bodies: bodies)
                     },
                     onMouseDown: { location, viewSize in
@@ -240,10 +240,14 @@ public struct MetalViewportView: View {
         TwoFingerPanGestureView(
             onChanged: { translation in
                 isPanning = true
-                controller.handlePan(translation: translation)
+                controller.dispatch(.twoFingerPanChanged(
+                    translation: SIMD2<Float>(Float(translation.width), Float(translation.height))
+                ))
             },
             onEnded: { velocity in
-                controller.endPan(velocity: velocity)
+                controller.dispatch(.twoFingerPanEnded(
+                    velocity: SIMD2<Float>(Float(velocity.width), Float(velocity.height))
+                ))
             }
         )
     }
@@ -259,15 +263,18 @@ public struct MetalViewportView: View {
                 )
                 lastDragValue = value.translation
 
-                // Negate horizontal so left/right swipe rotates the object
-                // under the finger (direct manipulation) rather than orbiting
-                // the camera around the object.
-                controller.handleOrbit(translation: CGSize(width: -delta.width, height: delta.height))
+                controller.dispatch(.dragChanged(
+                    delta: SIMD2<Float>(Float(delta.width), Float(delta.height)),
+                    modifiers: []
+                ))
             }
             .onEnded { value in
                 lastDragValue = .zero
                 if !isPanning {
-                    controller.endOrbit(velocity: CGSize(width: -value.velocity.width, height: value.velocity.height))
+                    controller.dispatch(.dragEnded(
+                        velocity: SIMD2<Float>(Float(value.velocity.width), Float(value.velocity.height)),
+                        modifiers: []
+                    ))
                 }
                 isPanning = false
                 controller.scheduleDynamicPivotUpdate(bodies: bodies)
@@ -279,10 +286,11 @@ public struct MetalViewportView: View {
             .onChanged { value in
                 let delta = value.magnification / lastMagnification
                 lastMagnification = value.magnification
-                controller.handleZoom(magnification: delta)
+                controller.dispatch(.pinchChanged(scale: Float(delta)))
             }
             .onEnded { _ in
                 lastMagnification = 1.0
+                controller.dispatch(.pinchEnded)
                 controller.scheduleDynamicPivotUpdate(bodies: bodies)
             }
     }
@@ -292,17 +300,18 @@ public struct MetalViewportView: View {
             .onChanged { value in
                 let delta = Float((value.rotation - lastRotation).radians)
                 lastRotation = value.rotation
-                controller.handleRoll(angle: CGFloat(delta))
+                controller.dispatch(.rotateChanged(radians: delta))
             }
             .onEnded { _ in
                 lastRotation = .zero
+                controller.dispatch(.rotateEnded)
             }
     }
 
     private var doubleTapGesture: some Gesture {
         TapGesture(count: 2)
             .onEnded {
-                controller.reset(animated: true)
+                controller.dispatch(.tap(ndc: .zero, count: 2))
             }
     }
     #endif
@@ -320,39 +329,18 @@ public struct MetalViewportView: View {
                 lastDragValue = value.translation
 
                 let modifiers = ViewportModifierKeys(NSApp.currentEvent?.modifierFlags ?? [])
-                let gc = controller.configuration.gestureConfiguration
-                let action = gc.dragAction(for: modifiers)
-
-                switch action {
-                case .pan:
-                    activeDragMode = .pan
-                    controller.handlePan(translation: delta)
-                case .zoom:
-                    activeDragMode = .zoom
-                    let zoomDelta = 1.0 + delta.height * 0.02
-                    controller.handleZoom(magnification: zoomDelta)
-                case .orbit:
-                    activeDragMode = .orbit
-                    controller.handleOrbit(translation: CGSize(width: -delta.width, height: delta.height))
-                case .none:
-                    break
-                default:
-                    break
-                }
+                controller.dispatch(.dragChanged(
+                    delta: SIMD2<Float>(Float(delta.width), Float(delta.height)),
+                    modifiers: modifiers
+                ))
             }
             .onEnded { value in
                 lastDragValue = .zero
-
-                switch activeDragMode {
-                case .orbit:
-                    controller.endOrbit(velocity: CGSize(width: -value.velocity.width, height: value.velocity.height))
-                case .pan:
-                    controller.endPan(velocity: value.velocity)
-                case .zoom:
-                    break
-                }
-                activeDragMode = .orbit
-
+                let modifiers = ViewportModifierKeys(NSApp.currentEvent?.modifierFlags ?? [])
+                controller.dispatch(.dragEnded(
+                    velocity: SIMD2<Float>(Float(value.velocity.width), Float(value.velocity.height)),
+                    modifiers: modifiers
+                ))
                 controller.scheduleDynamicPivotUpdate(bodies: bodies)
             }
     }
@@ -362,10 +350,11 @@ public struct MetalViewportView: View {
             .onChanged { value in
                 let delta = value.magnification / lastMagnification
                 lastMagnification = value.magnification
-                controller.handleZoom(magnification: delta)
+                controller.dispatch(.pinchChanged(scale: Float(delta)))
             }
             .onEnded { _ in
                 lastMagnification = 1.0
+                controller.dispatch(.pinchEnded)
                 controller.scheduleDynamicPivotUpdate(bodies: bodies)
             }
     }
@@ -375,10 +364,11 @@ public struct MetalViewportView: View {
             .onChanged { value in
                 let delta = Float((value.rotation - lastRotation).radians)
                 lastRotation = value.rotation
-                controller.handleRoll(angle: CGFloat(delta))
+                controller.dispatch(.rotateChanged(radians: delta))
             }
             .onEnded { _ in
                 lastRotation = .zero
+                controller.dispatch(.rotateEnded)
             }
     }
     #endif

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -66,8 +66,11 @@ public struct MetalViewportView: View {
                     #if os(iOS)
                     .overlay { panGestureOverlay }
                     .gesture(orbitGesture)
-                    .gesture(zoomGesture)
-                    .gesture(rollGesture)
+                    // Pinch and rotate are both two-finger continuous gestures;
+                    // they must be simultaneous or SwiftUI's default exclusivity
+                    // lets pinch win and rotate never fires.
+                    .simultaneousGesture(zoomGesture)
+                    .simultaneousGesture(rollGesture)
                     .gesture(
                         SpatialTapGesture()
                             .onEnded { value in
@@ -77,8 +80,9 @@ public struct MetalViewportView: View {
                     .gesture(doubleTapGesture)
                     #else
                     .gesture(macGestures)
-                    .gesture(macMagnifyGesture)
-                    .gesture(macRotateGesture)
+                    // Same exclusivity issue on the macOS trackpad.
+                    .simultaneousGesture(macMagnifyGesture)
+                    .simultaneousGesture(macRotateGesture)
                     #endif
 
                 if controller.showViewCube {

--- a/Sources/OCCTSwiftViewport/Views/ViewportController.swift
+++ b/Sources/OCCTSwiftViewport/Views/ViewportController.swift
@@ -329,6 +329,17 @@ public final class ViewportController: ObservableObject {
     /// Optional callback invoked when a widget-layer pick occurs.
     public var onWidgetPick: ((PickResult?) -> Void)?
 
+    /// Optional observer of the portable input-event stream, fired for every event
+    /// passed to `dispatch(_:)`. Useful for debugging / HUD input inspectors; does
+    /// not affect interpretation. See `ViewportInputEvent`.
+    public var onInputEvent: ((ViewportInputEvent) -> Void)?
+
+    /// Drag mode the unified pointer drag is currently interpreted as. Tracked
+    /// across `dragChanged` so `dragEnded` applies the matching inertia. Internal —
+    /// used by the input router (`dispatch(_:)`).
+    enum InputDragMode { case orbit, pan, zoom }
+    var activeInputDragMode: InputDragMode = .orbit
+
     /// Optional filter constraining what the user-geometry pick stream accepts.
     ///
     /// When set, a user-geometry pick that fails the filter is treated as a miss

--- a/Tests/OCCTSwiftViewportTests/ViewportInputRouterTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewportInputRouterTests.swift
@@ -1,0 +1,98 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@MainActor
+@Suite("Viewport input router")
+struct ViewportInputRouterTests {
+
+    // MARK: - Observation
+
+    @Test("onInputEvent fires with the exact event for every dispatch")
+    func observerReceivesEvents() {
+        let controller = ViewportController()
+        var seen: [ViewportInputEvent] = []
+        controller.onInputEvent = { seen.append($0) }
+
+        let events: [ViewportInputEvent] = [
+            .dragChanged(delta: SIMD2<Float>(5, 0), modifiers: []),
+            .dragEnded(velocity: .zero, modifiers: []),
+            .pinchChanged(scale: 1.1),
+            .pinchEnded,
+            .rotateChanged(radians: 0.2),
+            .rotateEnded,
+            .twoFingerPanChanged(translation: SIMD2<Float>(3, 4)),
+            .twoFingerPanEnded(velocity: .zero),
+            .scroll(delta: 1, cursorNDC: .zero, aspectRatio: 1),
+            .tap(ndc: .zero, count: 1)
+        ]
+        for e in events { controller.dispatch(e) }
+        #expect(seen == events)
+    }
+
+    // MARK: - Interpretation
+
+    @Test("Primary drag with default config orbits (rotation changes)")
+    func dragOrbits() {
+        let controller = ViewportController()
+        let before = controller.cameraState.rotation.vector
+        controller.dispatch(.dragChanged(delta: SIMD2<Float>(60, 0), modifiers: []))
+        #expect(controller.cameraState.rotation.vector != before)
+        #expect(controller.activeInputDragMode == .orbit)
+    }
+
+    @Test("Pinch zooms (distance changes)")
+    func pinchZooms() {
+        let controller = ViewportController()
+        let before = controller.cameraState.distance
+        controller.dispatch(.pinchChanged(scale: 1.5))
+        #expect(controller.cameraState.distance != before)
+    }
+
+    @Test("Two-finger pan moves the pivot")
+    func twoFingerPans() {
+        let controller = ViewportController()
+        let before = controller.cameraState.pivot
+        controller.dispatch(.twoFingerPanChanged(translation: SIMD2<Float>(40, 20)))
+        #expect(controller.cameraState.pivot != before)
+    }
+
+    @Test("Scroll zooms (distance changes)")
+    func scrollZooms() {
+        let controller = ViewportController()
+        let before = controller.cameraState.distance
+        controller.dispatch(.scroll(delta: 3, cursorNDC: .zero, aspectRatio: 1.0))
+        #expect(controller.cameraState.distance != before)
+    }
+
+    @Test("dragEnded resets the active drag mode to orbit")
+    func dragEndedResetsMode() {
+        let controller = ViewportController()
+        // Force a non-orbit mode first via a pan-resolving drag where possible.
+        controller.dispatch(.dragChanged(delta: SIMD2<Float>(10, 0), modifiers: []))
+        controller.dispatch(.dragEnded(velocity: .zero, modifiers: []))
+        #expect(controller.activeInputDragMode == .orbit)
+    }
+
+    @Test("Single tap routes no camera change; double tap is handled")
+    func tapRouting() {
+        let controller = ViewportController()
+        let before = controller.cameraState.rotation.vector
+        controller.dispatch(.tap(ndc: .zero, count: 1))
+        // Single tap performs no camera action (picking is a separate path).
+        #expect(controller.cameraState.rotation.vector == before)
+        // Double tap triggers reset (animated) — just exercise the path safely.
+        controller.dispatch(.tap(ndc: .zero, count: 2))
+    }
+
+    #if os(macOS)
+    @Test("macOS: modifier resolves drag action via GestureConfiguration")
+    func macModifierResolution() {
+        let controller = ViewportController()  // default: shift = pan
+        let pivotBefore = controller.cameraState.pivot
+        controller.dispatch(.dragChanged(delta: SIMD2<Float>(30, 10), modifiers: .shift))
+        #expect(controller.activeInputDragMode == .pan)
+        #expect(controller.cameraState.pivot != pivotBefore)
+    }
+    #endif
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.0.8] — 2026-06-05
+
+### Added
+- **Portable input-event model** (issue #35, completing the layer). A source-neutral event type plus a single observable dispatch entry, so synthetic / XR / test input can drive the camera without any AppKit / UIKit type.
+  - **`ViewportInputEvent`** — `Sendable` / `Equatable` enum (drag, two-finger pan, pinch, rotate, scroll, tap) with raw deltas. Re-exported as `_ViewportInputEvent`.
+  - **`ViewportController.dispatch(_:)`** — the single interpretation entry point. It owns gesture-action resolution, the orbit X-axis inversion, and the drag-to-zoom curve; the platform layer is now a thin native→event adapter. macOS resolves drag actions via modifiers (`dragAction(for:)`); iOS via `singleFingerDrag` (both config fields preserved — no behaviour change).
+  - **`ViewportController.onInputEvent`** — observation hook for the whole event stream (drives the demo's input inspector; useful for debugging / HUDs).
+  - iOS + macOS gesture, scroll, and tap handlers rerouted through `dispatch`; behaviour preserved (Views keep delta math + dynamic-pivot scheduling).
+  - New `ViewportInputRouterTests` (8 tests → 102 total, all green). iOS (arm64) + macOS demo builds verified.
+
+### Demo
+- **Input inspector** overlay (sidebar → Debug → "Input event inspector") showing the live `ViewportInputEvent` stream — for on-device verification of gesture interpretation.
+
+### Note
+- This closes the #35 follow-up. The shipped seam is what #36 (visionOS/XR) builds on: XR / synthetic input produces `ViewportInputEvent`s and calls `dispatch(_:)` directly.
+
 ## [1.0.7] — 2026-06-05
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to OCCTSwiftViewport are documented in this file.
 ### Demo
 - **Input inspector** overlay (sidebar → Debug → "Input event inspector") showing the live `ViewportInputEvent` stream — for on-device verification of gesture interpretation.
 
+### Fixed
+- **Two-finger rotate (roll) never fired on iOS / macOS trackpad.** Pinch and rotate were attached as separate `.gesture()` modifiers, which SwiftUI treats as mutually exclusive, so pinch always won. Both two-finger continuous gestures are now `.simultaneousGesture`, so pinch + rotate coexist. (Pre-existing bug, surfaced by on-device verification of #35.)
+
 ### Note
 - This closes the #35 follow-up. The shipped seam is what #36 (visionOS/XR) builds on: XR / synthetic input produces `ViewportInputEvent`s and calls `dispatch(_:)` directly.
 


### PR DESCRIPTION
Closes #35.

Completes the input-abstraction layer started in v1.0.7: a source-neutral **event model** plus a single **observable dispatch entry**, so synthetic / XR / test input can drive the camera with no AppKit/UIKit type. Designed for **on-device verification** before merge (see below).

## Library
- **`ViewportInputEvent`** — `Sendable` / `Equatable` enum (drag, two-finger pan, pinch, rotate, scroll, tap) carrying raw deltas. → `_ViewportInputEvent`
- **`ViewportController.dispatch(_:)`** — the single interpretation point. Owns gesture-action resolution, the orbit X-axis inversion, and the drag-to-zoom curve, so the platform layer is a thin native→event adapter. macOS resolves via modifiers (`dragAction(for:)`); iOS via `singleFingerDrag`. **Both config fields kept — behaviour preserved.**
- **`ViewportController.onInputEvent`** — observation hook for the whole stream.
- iOS + macOS gesture/scroll/tap handlers rerouted through `dispatch`; Views keep delta math + dynamic-pivot scheduling.

## Demo (verification harness)
- **Input inspector** overlay: sidebar → **Debug → "Input event inspector"**. Shows the live `ViewportInputEvent` stream (`drag Δ(..)`, `pinch ×1.04`, `2-finger pan`, `[⇧⌘]` modifiers, `double-tap → reset`).

## How to verify on device
1. `xcodegen generate` (already run) → `OCCTSwiftViewport.xcodeproj`
2. Open in Xcode, select scheme **OCCTSwiftMetalDemo_iOS**, your device, Run — or build+install via `xcrun devicectl`.
3. Toggle the inspector on and confirm each gesture maps correctly:
   - one-finger drag → `drag` + camera **orbits**
   - two-finger drag → `2-finger pan` + camera **pans**
   - pinch → `pinch ×…` + **zoom**
   - rotate → `rotate …°` + **roll**
   - double-tap → `double-tap → reset` + view **resets**

## Tests
`ViewportInputRouterTests` — 8 tests (observation, orbit/pan/zoom/scroll interpretation, drag-mode tracking, macOS modifier resolution). **102/102 pass.** iOS (arm64) + macOS demo builds verified green.

⚠️ **Do not merge until on-device behaviour is confirmed** — the refactor is behaviour-preserving by design but reroutes the live gesture pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
