### PR TITLE
feat(visionos): windowed visionOS support, Phases 0+1 (#36)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
     name: "OCCTSwiftViewport",
     platforms: [
         .iOS(.v18),
-        .macOS(.v15)
+        .macOS(.v15),
+        .visionOS(.v2)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     platforms: [
         .iOS(.v18),
         .macOS(.v15),
-        .visionOS(.v2)
+        .visionOS(.v1)
     ],
     products: [
         .library(

--- a/Sources/OCCTSwiftViewport/Renderer/MetalViewRepresentable.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/MetalViewRepresentable.swift
@@ -6,9 +6,10 @@
 import SwiftUI
 import MetalKit
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
-/// iOS wrapper for MTKView.
+/// UIKit (iOS / visionOS) wrapper for MTKView. visionOS runs this in a window /
+/// volume (shared space); the same `MTKView` + SwiftUI gesture path applies.
 struct MetalViewRepresentable: UIViewRepresentable {
     let renderer: ViewportRenderer
     let backgroundColor: SIMD4<Float>

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -294,6 +294,11 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
     /// to either `ViewportController.pickResult` or `widgetPickResult`.
     private var currentLayerMap: [String: PickLayer] = [:]
 
+    /// Most recent drawable size in pixels, updated each frame. Lets the view layer
+    /// derive the point→pixel scale without `UIScreen`/`NSScreen` (works on
+    /// iOS / macOS / visionOS alike).
+    public private(set) var lastDrawableSize: CGSize = .zero
+
     // MARK: - Initialization
 
     public init?(controller: ViewportController, bodies: Binding<[ViewportBody]>) {
@@ -1084,6 +1089,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
 
         let cameraState = controller.cameraState
         let drawableSize = view.drawableSize
+        lastDrawableSize = drawableSize
         let aspectRatio = Float(drawableSize.width / drawableSize.height)
 
         let viewMatrix = cameraState.viewMatrix

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -63,7 +63,7 @@ public struct MetalViewportView: View {
         GeometryReader { geometry in
             ZStack {
                 metalView
-                    #if os(iOS)
+                    #if os(iOS) || os(visionOS)
                     .overlay { panGestureOverlay }
                     .gesture(orbitGesture)
                     // Pinch and rotate are both two-finger continuous gestures;
@@ -149,23 +149,31 @@ public struct MetalViewportView: View {
     /// Converts a view-space point to drawable pixel coordinates.
     private func viewToPixel(_ point: CGPoint, viewSize: CGSize) -> SIMD2<Int>? {
         guard viewSize.width > 0, viewSize.height > 0 else { return nil }
-        let scale = nativeScaleFactor
+        let scale = nativeScaleFactor(viewSize: viewSize)
         let px = Int(point.x * scale)
         #if os(macOS)
         // macOS: AppKit origin is bottom-left, flip Y
         let py = Int((viewSize.height - point.y) * scale)
         #else
-        // iOS: UIKit origin is top-left, no flip needed
+        // UIKit (iOS / visionOS): origin is top-left, no flip needed
         let py = Int(point.y * scale)
         #endif
         return SIMD2<Int>(px, py)
     }
 
-    private var nativeScaleFactor: CGFloat {
+    /// Point→pixel scale, derived from the renderer's actual drawable size relative
+    /// to the view size. This is the exact ratio the GPU uses and needs no
+    /// `UIScreen`/`NSScreen` (the former is unavailable on visionOS). Falls back to a
+    /// platform default before the first frame establishes a drawable size.
+    private func nativeScaleFactor(viewSize: CGSize) -> CGFloat {
+        if let drawable = renderer?.lastDrawableSize,
+           drawable.width > 0, viewSize.width > 0 {
+            return drawable.width / viewSize.width
+        }
         #if os(macOS)
-        NSScreen.main?.backingScaleFactor ?? 2.0
+        return NSScreen.main?.backingScaleFactor ?? 2.0
         #else
-        UIScreen.main.scale
+        return 2.0
         #endif
     }
 
@@ -237,9 +245,9 @@ public struct MetalViewportView: View {
         }
     }
 
-    // MARK: - iOS Gestures
+    // MARK: - iOS / visionOS Gestures
 
-    #if os(iOS)
+    #if os(iOS) || os(visionOS)
     private var panGestureOverlay: some View {
         TwoFingerPanGestureView(
             onChanged: { translation in
@@ -423,9 +431,9 @@ public struct MetalViewportView: View {
     }
 }
 
-// MARK: - iOS Two-Finger Pan Gesture (Metal version)
+// MARK: - iOS / visionOS Two-Finger Pan Gesture (Metal version)
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 import UIKit
 
 /// A transparent UIView overlay that recognizes two-finger pan gestures via UIKit.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [Unreleased]
+
+### Added
+- **visionOS platform support — library (Phase 0 of #36).** The package now declares `.visionOS(.v2)` and the library compiles for visionOS (verified against `arm64-apple-xros2.0-simulator`). visionOS runs the existing UIKit `MTKView` + SwiftUI gesture path in a window / volume (shared space).
+  - `MetalViewRepresentable` and the `MetalViewportView` gesture / two-finger-pan code are now gated `#if os(iOS) || os(visionOS)` (UIKit is shared).
+  - Point→pixel scale for picking is derived from the renderer's actual drawable size (new `ViewportRenderer.lastDrawableSize`) instead of `UIScreen.main` (unavailable on visionOS) / `NSScreen.main` — more correct on all platforms and removes the screen-API dependency.
+  - No behaviour change on iOS / macOS; 102 tests green.
+  - Follow-ups (tracked in #36): demo visionOS target (Phase 1), spatial-input polish (Phase 2), immersive/XR (Phase 3).
+
 ## [1.0.8] — 2026-06-05
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
-## [Unreleased]
+## [1.1.0] — 2026-06-05
 
 ### Added
-- **visionOS platform support — library (Phase 0 of #36).** The package now declares `.visionOS(.v1)` (matching the OCCTSwift / OCCTSwiftTools ecosystem) and the library compiles for visionOS. visionOS runs the existing UIKit `MTKView` + SwiftUI gesture path in a window / volume (shared space).
-  - `MetalViewRepresentable` and the `MetalViewportView` gesture / two-finger-pan code are now gated `#if os(iOS) || os(visionOS)` (UIKit is shared).
+- **visionOS platform support (windowed / shared space)** — Phases 0+1 of #36. The viewport now builds and runs on visionOS, rendering through the existing UIKit `MTKView` + SwiftUI gesture path in a window / volume. Verified end-to-end on the Apple Vision Pro simulator (visionOS 26.5).
+  - `Package.swift` declares `.visionOS(.v1)` (matching the OCCTSwift / OCCTSwiftTools ecosystem; the library uses no visionOS-2-only APIs).
+  - `MetalViewRepresentable` and the `MetalViewportView` gesture / two-finger-pan code are gated `#if os(iOS) || os(visionOS)` (shared UIKit).
   - Point→pixel scale for picking is derived from the renderer's actual drawable size (new `ViewportRenderer.lastDrawableSize`) instead of `UIScreen.main` (unavailable on visionOS) / `NSScreen.main` — more correct on all platforms and removes the screen-API dependency.
+  - Demo (`Examples/MetalDemo`) gains a visionOS target / `OCCTSwiftMetalDemo_visionOS` scheme.
   - No behaviour change on iOS / macOS; 102 tests green.
-  - Follow-ups (tracked in #36): demo visionOS target (Phase 1), spatial-input polish (Phase 2), immersive/XR (Phase 3).
+  - Follow-ups tracked in #36: spatial-input polish (Phase 2), immersive / XR (Phase 3).
+
+> First minor bump in the 1.x line: a new platform is a capability expansion rather than a purely additive API, so it gets a MINOR rather than the usual PATCH.
 
 ## [1.0.8] — 2026-06-05
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OCCTSwiftViewport are documented in this file.
 ## [Unreleased]
 
 ### Added
-- **visionOS platform support — library (Phase 0 of #36).** The package now declares `.visionOS(.v2)` and the library compiles for visionOS (verified against `arm64-apple-xros2.0-simulator`). visionOS runs the existing UIKit `MTKView` + SwiftUI gesture path in a window / volume (shared space).
+- **visionOS platform support — library (Phase 0 of #36).** The package now declares `.visionOS(.v1)` (matching the OCCTSwift / OCCTSwiftTools ecosystem) and the library compiles for visionOS. visionOS runs the existing UIKit `MTKView` + SwiftUI gesture path in a window / volume (shared space).
   - `MetalViewRepresentable` and the `MetalViewportView` gesture / two-finger-pan code are now gated `#if os(iOS) || os(visionOS)` (UIKit is shared).
   - Point→pixel scale for picking is derived from the renderer's actual drawable size (new `ViewportRenderer.lastDrawableSize`) instead of `UIScreen.main` (unavailable on visionOS) / `NSScreen.main` — more correct on all platforms and removes the screen-API dependency.
   - No behaviour change on iOS / macOS; 102 tests green.

--- a/project.yml
+++ b/project.yml
@@ -4,6 +4,7 @@ options:
   deploymentTarget:
     iOS: "18.0"
     macOS: "15.0"
+    visionOS: "1.0"
   xcodeVersion: "16.0"
   generateEmptyDirectories: false
 
@@ -19,7 +20,7 @@ packages:
 targets:
   OCCTSwiftMetalDemo:
     type: application
-    platform: [macOS, iOS]
+    platform: [macOS, iOS, visionOS]
     sources:
       - path: Examples/MetalDemo/Sources/OCCTSwiftMetalDemo
     dependencies:


### PR DESCRIPTION
Phases 0 + 1 of #36 — **windowed (shared-space) visionOS support**. The viewport now builds and runs on visionOS, rendering through the existing UIKit `MTKView` + SwiftUI gesture path in a window / volume. **Verified end-to-end on the Apple Vision Pro simulator (visionOS 26.5)** — primitives, wireframe, ViewCube all render.

## Library (Phase 0)
- `Package.swift` declares `.visionOS(.v1)` (matches the OCCTSwift / OCCTSwiftTools ecosystem; no visionOS-2-only APIs are used).
- `MetalViewRepresentable` + `MetalViewportView` gesture / two-finger-pan code gated `#if os(iOS) || os(visionOS)` (shared UIKit).
- Pick point→pixel scale now derived from the renderer's drawable size (new `ViewportRenderer.lastDrawableSize`) instead of `UIScreen.main` (unavailable on visionOS) / `NSScreen.main` — more correct everywhere, drops the screen-API dependency.

## Demo (Phase 1)
- `project.yml`: `OCCTSwiftMetalDemo` targets visionOS → new `OCCTSwiftMetalDemo_visionOS` scheme.
- Full chain (viewport + OCCT + OCCTSwiftTools) builds, installs, launches, and renders in the simulator.

## Compatibility note
The library's visionOS min was lowered `.v2` → `.v1` during verification: OCCTSwiftTools depends back on the viewport and declares `.visionOS(.v1)`, so a v2 min was unresolvable. Caught by building the full dependency chain.

## Version
First minor bump in the 1.x line (**v1.1.0**) — a new platform is a capability expansion, not a purely additive API.

## Tests / verification
102/102 tests green; macOS + iOS + visionOS-sim builds all compile; demo confirmed rendering on the Vision Pro simulator.

Follow-ups stay open on #36: Phase 2 (spatial-input polish), Phase 3 (immersive / XR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
