### PR TITLE
feat(config): .performance preset + scaling guidance (#42 part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,45 @@ let config = ViewportConfiguration(
 // Also: .studio, .architectural, .flat
 ```
 
+## Performance & Scaling
+
+Large, many-body scenes (thousands of `ViewportBody` objects, hundreds of
+thousands of triangles) can stutter on mobile. The cost has two main sources —
+**per-frame whole-scene passes** and **per-body CPU overhead** — and there are
+two levers for each:
+
+```swift
+// 1. Use the performance preset: disables the expensive per-frame passes
+//    (directional shadow map, SSAO, MSAA, silhouettes).
+let controller = ViewportController(configuration: .performance)
+
+// or toggle the individual levers on any configuration:
+//   lightingConfiguration.shadowsEnabled = false
+//   lightingConfiguration.enableSSAO     = false
+//   msaaSampleCount = 1
+//   enableSilhouettes = false
+```
+
+**Batch many small static bodies.** Per-body overhead (buffer-cache lookups,
+uniform updates, encoder state changes) scales with body *count*, independent of
+triangle count — thousands of tiny bodies are far more expensive than a handful
+of large ones with the same total geometry. If your source produces one body per
+component (e.g. per mesh connected-component), **merge components that share a
+material into a single `ViewportBody`** before handing them to the viewport. You
+can keep sub-component picking by maintaining a triangle→component map and using
+`ViewportBody.faceIndices`.
+
+**Rules of thumb**
+- Aim for **low hundreds of bodies**, not thousands. Merging ~thousands of
+  bodies down to dozens is typically the single biggest win.
+- For dense scenes on iPhone/iPad, start from `.performance`.
+- Triangle count matters less than body count for CPU cost; the GPU handles
+  a few hundred thousand triangles comfortably once the per-body overhead is
+  contained.
+
+> Renderer-side scaling work (frustum culling, reduced per-body overhead) is
+> tracked in [issue #42](https://github.com/gsdali/OCCTSwiftViewport/issues/42).
+
 ## GPU Picking and Selection
 
 ```swift

--- a/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
@@ -288,6 +288,30 @@ public struct ViewportConfiguration: Sendable {
         showViewCube: true,
         showGrid: true
     )
+
+    /// Configuration tuned for large / many-body scenes on mobile (issue #42).
+    ///
+    /// Disables the per-frame whole-scene passes that dominate cost on big models
+    /// (directional shadow map, SSAO, MSAA, silhouettes), giving a discoverable
+    /// fast path instead of hand-assembling the levers. Keep this for dense scenes
+    /// (thousands of bodies / hundreds of thousands of triangles) on iPhone / iPad;
+    /// see the README "Scaling" section for batching guidance and recommended body
+    /// counts.
+    public static let performance: ViewportConfiguration = {
+        var lighting = LightingConfiguration.threePoint
+        lighting.shadowsEnabled = false
+        lighting.enableSSAO = false
+        return ViewportConfiguration(
+            rotationStyle: .turntable,
+            lightingConfiguration: lighting,
+            showViewCube: true,
+            showAxes: true,
+            showGrid: true,
+            msaaSampleCount: 1,
+            enableSilhouettes: false,
+            renderingQuality: .standard
+        )
+    }()
 }
 
 // MARK: - ViewCube Position

--- a/Tests/OCCTSwiftViewportTests/ViewportConfigurationTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewportConfigurationTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import OCCTSwiftViewport
+
+@Suite("ViewportConfiguration presets")
+struct ViewportConfigurationTests {
+
+    @Test("performance preset disables the expensive per-frame passes (#42)")
+    func performancePresetDisablesHeavyPasses() {
+        let config = ViewportConfiguration.performance
+        #expect(config.lightingConfiguration.shadowsEnabled == false)
+        #expect(config.lightingConfiguration.enableSSAO == false)
+        #expect(config.msaaSampleCount == 1)
+        #expect(config.enableSilhouettes == false)
+    }
+
+    @Test("Default (.cad) keeps the quality passes on")
+    func cadKeepsQualityOn() {
+        let config = ViewportConfiguration.cad
+        #expect(config.msaaSampleCount > 1)
+        #expect(config.enableSilhouettes == true)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.1] — 2026-06-05
+
+### Added
+- **`ViewportConfiguration.performance` preset** (issue #42, part 1) — a discoverable fast path for large / many-body scenes on mobile. Disables the per-frame whole-scene passes that dominate cost on big models: directional shadow map, SSAO, MSAA (sample count 1), and silhouettes. Replaces hand-assembling those levers.
+- **README "Performance & Scaling" section** — guidance on the two cost sources (per-frame passes vs per-body CPU overhead), batching many small static bodies into shared-material `ViewportBody`s (keeping sub-component picking via `faceIndices`), and recommended body counts.
+- New `ViewportConfigurationTests` (2 tests → 104 total).
+
+Renderer-side scaling (frustum culling, reduced per-body overhead) continues in #42.
+
 ## [1.1.0] — 2026-06-05
 
 ### Added


### PR DESCRIPTION
Part 1 of #42. The quick, self-contained win: a discoverable fast path for large many-body scenes.

## Added
- **`ViewportConfiguration.performance`** — disables the per-frame whole-scene passes that dominate cost on big models: directional shadow map, SSAO, MSAA (=1), silhouettes. Replaces consumers hand-assembling these levers.
- **README “Performance & Scaling”** — the two cost sources (per-frame passes vs per-body overhead), how to batch many small static bodies into shared-material `ViewportBody`s (keeping picking via `faceIndices`), and recommended body counts (low hundreds, not thousands).
- `ViewportConfigurationTests` (2 tests → 104 total, all green).

Renderer-side scaling (frustum culling → part 2; per-body overhead → part 3) continues in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)