### PR TITLE
feat(renderer): per-body frustum culling (#42 part 2)

### DIFF
--- a/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
@@ -135,6 +135,13 @@ public struct ViewportConfiguration: Sendable {
     /// Silhouette edge darkness (0 = invisible, 1 = fully dark).
     public var silhouetteIntensity: Float
 
+    /// Whether to frustum-cull bodies whose world-space bounds fall entirely
+    /// outside the camera view (issue #42). On by default — off-screen bodies are
+    /// not visible anyway, and skipping them is the main lever for large scenes.
+    /// Bodies with no `boundingBox` are never culled. The shadow pass is not
+    /// culled by the camera frustum (off-screen casters can shadow visible geometry).
+    public var enableFrustumCulling: Bool
+
     // MARK: - Picking
 
     /// Configuration for GPU-accelerated picking.
@@ -206,6 +213,7 @@ public struct ViewportConfiguration: Sendable {
         enableSilhouettes: Bool = true,
         silhouetteThickness: Float = 1.0,
         silhouetteIntensity: Float = 0.7,
+        enableFrustumCulling: Bool = true,
         pickingConfiguration: PickingConfiguration = .init(),
         enableDepthOfField: Bool = false,
         dofAperture: Float = 2.8,
@@ -245,6 +253,7 @@ public struct ViewportConfiguration: Sendable {
         self.enableSilhouettes = enableSilhouettes
         self.silhouetteThickness = silhouetteThickness
         self.silhouetteIntensity = silhouetteIntensity
+        self.enableFrustumCulling = enableFrustumCulling
         self.pickingConfiguration = pickingConfiguration
         self.enableDepthOfField = enableDepthOfField
         self.dofAperture = dofAperture

--- a/Sources/OCCTSwiftViewport/Math/Frustum.swift
+++ b/Sources/OCCTSwiftViewport/Math/Frustum.swift
@@ -1,0 +1,84 @@
+// Frustum.swift
+// ViewportKit
+//
+// View-frustum extraction + AABB intersection for per-body culling (issue #42).
+
+import simd
+
+/// The six planes of a view frustum, extracted from a view-projection matrix.
+///
+/// Each plane is stored as `SIMD4(a, b, c, d)` with the normal `(a, b, c)`
+/// pointing **inward**; a world point `p` is inside the plane when
+/// `dot(normal, p) + d >= 0`. Uses the Gribb–Hartmann method with Metal's
+/// `[0, 1]` clip-space depth convention.
+public struct Frustum: Sendable {
+
+    /// left, right, bottom, top, near, far.
+    public let planes: [SIMD4<Float>]
+
+    /// Extracts the frustum from a world→clip `viewProjection` matrix.
+    public init(viewProjection m: simd_float4x4) {
+        // simd matrices are column-major: m[col][row]. Row i across columns:
+        func row(_ i: Int) -> SIMD4<Float> {
+            SIMD4<Float>(m[0][i], m[1][i], m[2][i], m[3][i])
+        }
+        let r0 = row(0), r1 = row(1), r2 = row(2), r3 = row(3)
+
+        var planes = [
+            r3 + r0,   // left
+            r3 - r0,   // right
+            r3 + r1,   // bottom
+            r3 - r1,   // top
+            r2,        // near  (Metal [0,1] depth: near = row2, not row3+row2)
+            r3 - r2    // far
+        ]
+        for i in planes.indices {
+            let len = simd_length(SIMD3<Float>(planes[i].x, planes[i].y, planes[i].z))
+            if len > 0 { planes[i] /= len }
+        }
+        self.planes = planes
+    }
+
+    /// Returns `false` only when `box` lies entirely outside at least one plane
+    /// (i.e. it is safe to cull). Conservative: a straddling box returns `true`.
+    public func intersects(_ box: BoundingBox) -> Bool {
+        for plane in planes {
+            let n = SIMD3<Float>(plane.x, plane.y, plane.z)
+            // p-vertex: the AABB corner furthest along the (inward) plane normal.
+            let p = SIMD3<Float>(
+                n.x >= 0 ? box.max.x : box.min.x,
+                n.y >= 0 ? box.max.y : box.min.y,
+                n.z >= 0 ? box.max.z : box.min.z
+            )
+            if simd_dot(n, p) + plane.w < 0 {
+                return false   // fully outside this plane → cull
+            }
+        }
+        return true
+    }
+}
+
+extension BoundingBox {
+
+    /// The world-space AABB enclosing this box after `transform`.
+    ///
+    /// Transforms all eight corners and takes their extent. Returns `self`
+    /// unchanged for an identity transform (the common case) without work.
+    public func transformed(by transform: simd_float4x4) -> BoundingBox {
+        if transform == matrix_identity_float4x4 { return self }
+
+        var newMin = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var newMax = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        for xi in [min.x, max.x] {
+            for yi in [min.y, max.y] {
+                for zi in [min.z, max.z] {
+                    let c = transform * SIMD4<Float>(xi, yi, zi, 1)
+                    let p = SIMD3<Float>(c.x, c.y, c.z)
+                    newMin = simd_min(newMin, p)
+                    newMax = simd_max(newMax, p)
+                }
+            }
+        }
+        return BoundingBox(min: newMin, max: newMax)
+    }
+}

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -170,6 +170,9 @@ private struct BodyBuffers {
     /// empty. SIMD4<Float> RGBA per triangle, indexed by `[[primitive_id]]`
     /// in the highlight fragment shader.
     let triangleStyleBuffer: MTLBuffer?
+    /// The body's local-space AABB, computed once when buffers are built. Cached
+    /// here so per-frame frustum culling (issue #42) doesn't rescan vertices.
+    let localBoundingBox: BoundingBox?
 }
 
 // MARK: - ViewportRenderer
@@ -1228,6 +1231,22 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         currentIndexMap = indexMap
         currentLayerMap = layerMap
 
+        // Per-body frustum culling (issue #42): skip bodies whose world-space
+        // bounds fall entirely outside the camera, computed once per frame from
+        // cached local AABBs. Applied to the main geometry pass; the shadow pass is
+        // intentionally not camera-culled (off-screen casters can shadow visible
+        // geometry), and bodies with no bounds are never culled.
+        var culledBodyIDs: Set<String> = []
+        if controller.configuration.enableFrustumCulling {
+            let frustum = Frustum(viewProjection: viewProjection)
+            for body in bodies where body.isVisible && body.renderLayer == .geometry {
+                guard let localBox = bodyBufferCache[body.id]?.localBoundingBox else { continue }
+                if !frustum.intersects(localBox.transformed(by: body.transform)) {
+                    culledBodyIDs.insert(body.id)
+                }
+            }
+        }
+
         let silhouettesEnabled = controller.configuration.enableSilhouettes
         let ssaoEnabled = (lighting.enableSSAO || silhouettesEnabled) && ssaoPipeline != nil && displayMode.showsSurfaces
         let taaEnabled = controller.enableTAA && taaPipeline != nil
@@ -1417,6 +1436,9 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         for body in bodies where body.isVisible {
             let bodyObjectIndex = objectIndex
             objectIndex += 1
+            // Frustum-culled (off-screen) bodies are skipped here, but objectIndex
+            // still advances so the remaining bodies keep their stable pick IDs.
+            if culledBodyIDs.contains(body.id) { continue }
             guard let buffers = bodyBufferCache[body.id] else {
                 continue
             }
@@ -2401,7 +2423,8 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             vertexCount: vertexCount,
             tessellation: tessBuffers,
             meshlets: meshletBufs,
-            triangleStyleBuffer: triStyleBuf
+            triangleStyleBuffer: triStyleBuf,
+            localBoundingBox: body.boundingBox
         )
         bodyGeneration[body.id] = currentGen
     }

--- a/Tests/OCCTSwiftViewportTests/FrustumTests.swift
+++ b/Tests/OCCTSwiftViewportTests/FrustumTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@Suite("Frustum culling")
+struct FrustumTests {
+
+    /// A view-projection from the default camera (distance 10, looking at origin).
+    private static func defaultVP(aspect: Float = 1.0) -> simd_float4x4 {
+        let cs = CameraState()
+        return cs.projectionMatrix(aspectRatio: aspect, near: 0.01, far: 10000.0) * cs.viewMatrix
+    }
+
+    @Test("A box at the look-at point is inside the frustum")
+    func boxAtOriginInside() {
+        let f = Frustum(viewProjection: Self.defaultVP())
+        let box = BoundingBox(min: SIMD3(-1, -1, -1), max: SIMD3(1, 1, 1))
+        #expect(f.intersects(box))
+    }
+
+    @Test("A box far off to the side is culled")
+    func boxFarToSideCulled() {
+        let f = Frustum(viewProjection: Self.defaultVP())
+        let box = BoundingBox(min: SIMD3(100, 0, 0), max: SIMD3(101, 1, 1))
+        #expect(f.intersects(box) == false)
+    }
+
+    @Test("A box far behind the look-at (beyond far plane region) off-axis is culled")
+    func boxFarBehindCulled() {
+        let f = Frustum(viewProjection: Self.defaultVP())
+        // Far up and to the side — clearly outside the lateral frustum.
+        let box = BoundingBox(min: SIMD3(0, 500, 0), max: SIMD3(1, 501, 1))
+        #expect(f.intersects(box) == false)
+    }
+
+    @Test("A huge box enclosing the frustum is kept")
+    func hugeBoxKept() {
+        let f = Frustum(viewProjection: Self.defaultVP())
+        let box = BoundingBox(min: SIMD3(-1000, -1000, -1000), max: SIMD3(1000, 1000, 1000))
+        #expect(f.intersects(box))
+    }
+
+    @Test("A box straddling the frustum edge is conservatively kept")
+    func straddlingKept() {
+        let f = Frustum(viewProjection: Self.defaultVP())
+        // Spans from the centre out past the side — must not be culled.
+        let box = BoundingBox(min: SIMD3(-1, -1, -1), max: SIMD3(100, 1, 1))
+        #expect(f.intersects(box))
+    }
+
+    // MARK: - BoundingBox.transformed
+
+    @Test("Identity transform returns the same box")
+    func identityTransform() {
+        let box = BoundingBox(min: SIMD3(-1, -2, -3), max: SIMD3(4, 5, 6))
+        #expect(box.transformed(by: matrix_identity_float4x4) == box)
+    }
+
+    @Test("Translation shifts both corners")
+    func translationShifts() {
+        let box = BoundingBox(min: SIMD3(-1, -1, -1), max: SIMD3(1, 1, 1))
+        var t = matrix_identity_float4x4
+        t.columns.3 = SIMD4(10, 20, 30, 1)
+        let moved = box.transformed(by: t)
+        #expect(moved.min == SIMD3<Float>(9, 19, 29))
+        #expect(moved.max == SIMD3<Float>(11, 21, 31))
+    }
+
+    @Test("A translated body is culled when its bounds move off-screen")
+    func translatedBodyCulled() {
+        let f = Frustum(viewProjection: Self.defaultVP())
+        let local = BoundingBox(min: SIMD3(-0.5, -0.5, -0.5), max: SIMD3(0.5, 0.5, 0.5))
+        // At origin: visible.
+        #expect(f.intersects(local.transformed(by: matrix_identity_float4x4)))
+        // Translated far to the side: culled.
+        var t = matrix_identity_float4x4
+        t.columns.3 = SIMD4(200, 0, 0, 1)
+        #expect(f.intersects(local.transformed(by: t)) == false)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.2] — 2026-06-05
+
+### Added
+- **Per-body frustum culling** (issue #42, part 2) — the main lever for large scenes. Bodies whose world-space bounds fall entirely outside the camera are skipped in the main geometry pass, so cost scales with what's *on screen* rather than total body count.
+  - New `Frustum` (Gribb–Hartmann plane extraction, Metal `[0,1]` depth) with a conservative AABB `intersects(_:)`, and `BoundingBox.transformed(by:)` for world-space bounds (identity-transform fast path).
+  - Per-body local AABBs are computed once and cached in the renderer's buffer cache (no per-frame vertex rescans); the culled set is built once per frame.
+  - Pick-ID indices stay stable (culled bodies still advance the object index). The shadow pass is **not** camera-culled (off-screen casters can shadow visible geometry); bodies with no bounding box are never culled.
+  - New `ViewportConfiguration.enableFrustumCulling` (default `true` — off-screen bodies aren't visible anyway; set `false` to opt out).
+  - New `Frustum`/`BoundingBox.transformed` tests (8 → 112 total). Verified rendering unchanged on the Vision Pro simulator.
+
+Per-body CPU overhead reduction continues in #42 (part 3).
+
 ## [1.1.1] — 2026-06-05
 
 ### Added


### PR DESCRIPTION
Part 2 of #42 — the main renderer-side lever. Bodies whose world-space bounds fall entirely outside the camera are skipped in the main geometry pass, so cost scales with on-screen content rather than total body count.

## Added
- **`Frustum`** — Gribb–Hartmann plane extraction (Metal `[0,1]` depth) with a conservative AABB `intersects(_:)`.
- **`BoundingBox.transformed(by:)`** — world-space bounds with an identity-transform fast path.
- Per-body local AABBs cached in the renderer buffer cache (no per-frame vertex rescans — `ViewportBody.boundingBox` scans all vertices, so this is essential); culled set built once per frame.
- **`ViewportConfiguration.enableFrustumCulling`** (default `true`; off-screen bodies aren’t visible anyway).

## Correctness
- Pick-ID indices stay stable — culled bodies still advance the object index.
- The **shadow pass is not camera-culled** (off-screen casters can shadow visible geometry).
- Bodies with **no bounding box are never culled**.

## Tests / verification
- `FrustumTests` (8): origin-inside, far-side-culled, huge-box-kept, straddle-kept, translated-body-culled, plus `transformed` cases. **112/112 total green.**
- Rendering confirmed unchanged on the Vision Pro simulator (primitives not wrongly culled).

Part 3 (per-body CPU overhead) continues in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)