### PR TITLE
perf(renderer): resolve visible bodies once per frame (#42 part 3, closes #42)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -1221,31 +1221,32 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         var layerMap: [String: PickLayer] = [:]
         var objectIndex: UInt32 = 0
 
-        // Ensure buffers for all visible bodies
+        // Ensure buffers for all visible bodies, and resolve each body's buffers +
+        // stable pick index ONCE per frame (issue #42 part 3). The main draw pass
+        // iterates this list instead of re-filtering `bodies` and re-hashing the
+        // String-keyed `bodyBufferCache[body.id]` every pass.
+        var frameVisibleBodies: [(body: ViewportBody, buffers: BodyBuffers, objectIndex: UInt32)] = []
+        frameVisibleBodies.reserveCapacity(bodies.count)
         for body in bodies where body.isVisible {
             ensureBuffers(for: body)
             indexMap[Int(objectIndex)] = body.id
             layerMap[body.id] = body.pickLayer
+            if let bufs = bodyBufferCache[body.id] {
+                frameVisibleBodies.append((body, bufs, objectIndex))
+            }
             objectIndex += 1
         }
         currentIndexMap = indexMap
         currentLayerMap = layerMap
 
-        // Per-body frustum culling (issue #42): skip bodies whose world-space
-        // bounds fall entirely outside the camera, computed once per frame from
-        // cached local AABBs. Applied to the main geometry pass; the shadow pass is
-        // intentionally not camera-culled (off-screen casters can shadow visible
-        // geometry), and bodies with no bounds are never culled.
-        var culledBodyIDs: Set<String> = []
-        if controller.configuration.enableFrustumCulling {
-            let frustum = Frustum(viewProjection: viewProjection)
-            for body in bodies where body.isVisible && body.renderLayer == .geometry {
-                guard let localBox = bodyBufferCache[body.id]?.localBoundingBox else { continue }
-                if !frustum.intersects(localBox.transformed(by: body.transform)) {
-                    culledBodyIDs.insert(body.id)
-                }
-            }
-        }
+        // Per-body frustum culling (issue #42): off-screen bodies are skipped
+        // inline in the main pass below, using the cached local AABB — no per-frame
+        // Set / extra String hashing. The shadow pass is intentionally not
+        // camera-culled (off-screen casters can shadow visible geometry); bodies
+        // with no bounds are never culled.
+        let cullFrustum: Frustum? = controller.configuration.enableFrustumCulling
+            ? Frustum(viewProjection: viewProjection)
+            : nil
 
         let silhouettesEnabled = controller.configuration.enableSilhouettes
         let ssaoEnabled = (lighting.enableSSAO || silhouettesEnabled) && ssaoPipeline != nil && displayMode.showsSurfaces
@@ -1432,14 +1433,13 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         let selectedIDs = controller.selectedBodyIDs
         let hoveredID = controller.hoveredBodyID
 
-        objectIndex = 0
-        for body in bodies where body.isVisible {
-            let bodyObjectIndex = objectIndex
-            objectIndex += 1
-            // Frustum-culled (off-screen) bodies are skipped here, but objectIndex
-            // still advances so the remaining bodies keep their stable pick IDs.
-            if culledBodyIDs.contains(body.id) { continue }
-            guard let buffers = bodyBufferCache[body.id] else {
+        for (body, buffers, bodyObjectIndex) in frameVisibleBodies {
+            // Frustum-cull off-screen geometry inline using the cached local AABB.
+            // Pick IDs stay stable: bodyObjectIndex was assigned over all visible
+            // bodies, independent of culling.
+            if let cullFrustum, body.renderLayer == .geometry,
+               let localBox = buffers.localBoundingBox,
+               !cullFrustum.intersects(localBox.transformed(by: body.transform)) {
                 continue
             }
             // Overlay bodies are drawn after the selection outline, in their own pass.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.3] — 2026-06-05
+
+### Changed
+- **Reduced per-body CPU overhead in the main draw pass** (issue #42, part 3) — closes #42. Each visible body's GPU buffers and stable pick index are now resolved **once per frame** into a single list that the main geometry pass iterates, instead of re-filtering `bodies` and re-hashing the `String`-keyed `bodyBufferCache[body.id]` on the pass. Frustum culling moved inline on that list using the cached local AABB, dropping the separate per-frame `Set<String>` and its extra per-body hash. No render or API change (verified unchanged on the Vision Pro simulator); 112 tests green.
+
+The remaining larger lever for extreme body counts — merging many small static bodies — is consumer-side and documented in the README "Performance & Scaling" section.
+
 ## [1.1.2] — 2026-06-05
 
 ### Added


### PR DESCRIPTION
Part 3 of #42 — closes the issue. Reduces the per-body CPU overhead the issue identified (repeated `String`-keyed `bodyBufferCache` lookups).

## Change
The main geometry pass now iterates a per-frame list of `(body, buffers, pickIndex)` resolved **once** in the ensure-buffers loop, instead of re-filtering `bodies` and re-hashing `bodyBufferCache[body.id]` on the pass. Frustum culling is inline on that list using the cached local AABB — dropping the separate per-frame `Set<String>` (from v1.1.2) and its extra per-body hash.

Net: the hot loop goes from ~2 String hashes/body (cull-set + buffer-cache) to ~1 (the single resolve in the ensure loop), plus the Set construction is gone.

## Correctness
- Pick IDs unchanged (the resolved index is assigned over all visible bodies, as before).
- Same draws, same cull results — **render verified identical on the Vision Pro simulator**.
- 112/112 tests green.

## Scope note
The largest lever for extreme body counts — merging many small static bodies — is consumer-side and documented in the README “Performance & Scaling” section (added in v1.1.1).

With this, #42 is complete: `.performance` preset (v1.1.1) + frustum culling (v1.1.2) + per-body overhead (here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)