### PR TITLE
feat(visionos): GestureConfiguration.visionOS spatial-input preset (#36 Phase 2)

### DIFF
--- a/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -9,15 +9,25 @@ import OCCTSwiftViewport
 import OCCTSwiftTools
 
 struct SpikeView: View {
-    @StateObject private var controller = ViewportController(
-        configuration: ViewportConfiguration(
+    @StateObject private var controller = ViewportController(configuration: SpikeView.makeConfiguration())
+
+    /// Builds the viewport configuration, using the visionOS-tuned gesture preset
+    /// when running on visionOS (issue #36, Phase 2).
+    private static func makeConfiguration() -> ViewportConfiguration {
+        #if os(visionOS)
+        let gestures: GestureConfiguration = .visionOS
+        #else
+        let gestures: GestureConfiguration = .default
+        #endif
+        return ViewportConfiguration(
             rotationStyle: .turntable,
+            gestureConfiguration: gestures,
             showViewCube: true,
             showAxes: true,
             showGrid: true,
             pickingConfiguration: PickingConfiguration(isEnabled: true)
         )
-    )
+    }
 
     @StateObject private var selectionManager = SelectionManager()
 

--- a/Sources/OCCTSwiftViewport/Configuration/GestureConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/GestureConfiguration.swift
@@ -137,6 +137,20 @@ public struct GestureConfiguration: Sendable {
         commandDrag: .zoom
     )
 
+    /// Gesture configuration tuned for visionOS spatial (indirect pinch + look)
+    /// input in a window / volume (issue #36, Phase 2).
+    ///
+    /// Keeps the touch-style mapping (single pinch-drag orbits; two-handed
+    /// pinch/twist zoom/roll via the magnify/rotate gestures), and raises inertia
+    /// damping a little so momentum settles more predictably with indirect input.
+    ///
+    /// - Note: These are a sensible **starting point**. Indirect spatial input
+    ///   ultimately feels different from a touchscreen, so the sensitivities are
+    ///   best fine-tuned on Vision Pro hardware.
+    public static let visionOS = GestureConfiguration(
+        dampingFactor: 0.15
+    )
+
     // MARK: - Input Interpretation
 
     /// Resolves the action for a pointer drag given the active modifier keys.

--- a/Tests/OCCTSwiftViewportTests/InputAbstractionTests.swift
+++ b/Tests/OCCTSwiftViewportTests/InputAbstractionTests.swift
@@ -59,6 +59,16 @@ struct InputAbstractionTests {
         #expect(fusion.dragAction(for: .command) == .zoom)
     }
 
+    @Test("visionOS preset keeps touch-style mapping with steadier inertia")
+    func visionOSPreset() {
+        let v = GestureConfiguration.visionOS
+        // Same orbit-on-drag mapping as the default touch path.
+        #expect(v.singleFingerDrag == GestureConfiguration.default.singleFingerDrag)
+        #expect(v.enableInertia)
+        // Damping raised vs default for more predictable settling with indirect input.
+        #expect(v.dampingFactor > GestureConfiguration.default.dampingFactor)
+    }
+
     // MARK: - Platform bridge
 
     #if canImport(AppKit)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.4] — 2026-06-05
+
+### Added
+- **`GestureConfiguration.visionOS` preset** (issue #36, Phase 2) — a spatial-input starting point for windowed / volumetric visionOS. Keeps the touch-style mapping (single pinch-drag orbits; two-handed pinch/twist zoom/roll) and raises inertia damping for more predictable settling with indirect (pinch + look) input. Re-exported via `_GestureConfiguration`. The demo adopts it automatically on visionOS.
+  - New preset test (113 total). Builds + runs on the Vision Pro simulator.
+
+> The exact sensitivities are a starting point: indirect spatial input feels different from a touchscreen, so final tuning — and richer `SpatialEventGesture` integration — is best done on Vision Pro hardware. Tracked in #36 (Phase 2 refinement); immersive / XR is Phase 3.
+
 ## [1.1.3] — 2026-06-05
 
 ### Changed


### PR DESCRIPTION
Phase 2 of #36 (spatial-input polish), the verifiable part.

## Added
- **`GestureConfiguration.visionOS`** — a spatial-input starting point for windowed/volumetric visionOS. Keeps the touch-style mapping (single pinch-drag orbits; two-handed pinch/twist zoom/roll via magnify/rotate) and raises inertia damping for more predictable settling with indirect (pinch + look) input. Re-exported via `_GestureConfiguration`.
- The demo adopts it automatically on visionOS (platform-aware config factory).
- Preset test (113 total). Demo builds + runs on the Vision Pro simulator.

## Honest scope note
The simulator’s pinch emulation isn’t representative of real spatial input, so the exact sensitivities are a **starting point** rather than hardware-tuned. Final feel-tuning and richer `SpatialEventGesture` integration are best done on Vision Pro hardware — left as a Phase 2 refinement in #36. Immersive / XR is Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)