### PR TITLE
feat(config): cadHighQuality preset for smooth round geometry (#48 part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,37 @@ can keep sub-component picking by maintaining a triangle→component map and usi
 > Renderer-side scaling work (frustum culling, reduced per-body overhead) is
 > tracked in [issue #42](https://github.com/gsdali/OCCTSwiftViewport/issues/42).
 
+## Smooth Round Geometry
+
+Round surfaces (cylinder / cone silhouettes, fillets) can look faceted if the
+mesh you supply is coarsely tessellated. The renderer has **screen-space-adaptive
+PN-triangle (Phong) tessellation** that smooths curved silhouettes on the GPU,
+refining by projected size each frame — so a cylinder stays round at any zoom
+without you guessing a tessellation density. It's off in the default `.standard`
+quality; turn it on with the CAD-quality preset (or the quality knobs directly):
+
+```swift
+// Smooth curved surfaces, adaptive to zoom:
+let controller = ViewportController(configuration: .cadHighQuality)
+
+// or set the knobs on any configuration:
+//   renderingQuality     = .enhanced     // enables GPU PN-triangle tessellation
+//   adaptiveTessellation = true          // refine by projected size (vs fixed)
+//   tessellationMaxFactor = 48           // upper bound on subdivision (1...64)
+```
+
+**What controls smoothness**
+- **Surfaces:** `renderingQuality = .enhanced` (or `.maximum`) enables adaptive
+  Phong tessellation. Requires an Apple3+ GPU (falls back gracefully). Needs
+  reasonable per-vertex normals on the input mesh — OCCT meshes provide these; for
+  flat-normalled meshes, run `NormalSmoothing.smoothNormals(vertexData:indices:creaseAngle:)`
+  first (crease-aware, so hard edges stay sharp).
+- **Feature edges:** edges are drawn as polylines, so a circular edge is only as
+  smooth as its sampling. Sample BREP edges finely (e.g. 64+ points per circle)
+  until analytic arc edges land — see [issue #48](https://github.com/gsdali/OCCTSwiftViewport/issues/48).
+- **Tradeoff:** tessellation adds GPU work — prefer `.performance` for very large
+  many-body scenes (see Performance & Scaling above).
+
 ## GPU Picking and Selection
 
 ```swift

--- a/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
@@ -321,6 +321,29 @@ public struct ViewportConfiguration: Sendable {
             renderingQuality: .standard
         )
     }()
+
+    /// CAD configuration tuned for smooth round geometry (issue #48).
+    ///
+    /// Enables the GPU's screen-space-adaptive PN-triangle (Phong) tessellation
+    /// (`renderingQuality = .enhanced`), so curved surfaces — cylinder / cone
+    /// silhouettes, filleted faces — stay smooth at any zoom without the consumer
+    /// pre-tessellating finely. Tessellation refines by projected size and surface
+    /// curvature each frame, so it doesn't waste triangles on small / distant parts.
+    ///
+    /// - Note: This is the smoothness counterpart to `.performance`. Tessellation
+    ///   adds GPU work, so prefer `.performance` for very large many-body scenes
+    ///   (see #42). Smooth silhouettes need reasonable per-vertex normals on the
+    ///   input mesh; OCCT meshes provide these. Requires an Apple3+ GPU (falls back
+    ///   to un-tessellated rendering otherwise).
+    public static let cadHighQuality = ViewportConfiguration(
+        rotationStyle: .turntable,
+        showViewCube: true,
+        showAxes: true,
+        showGrid: true,
+        renderingQuality: .enhanced,
+        tessellationMaxFactor: 48,
+        adaptiveTessellation: true
+    )
 }
 
 // MARK: - ViewCube Position

--- a/Tests/OCCTSwiftViewportTests/ViewportConfigurationTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewportConfigurationTests.swift
@@ -19,4 +19,14 @@ struct ViewportConfigurationTests {
         #expect(config.msaaSampleCount > 1)
         #expect(config.enableSilhouettes == true)
     }
+
+    @Test("cadHighQuality enables adaptive GPU tessellation for smooth curves (#48)")
+    func cadHighQualityEnablesTessellation() {
+        let config = ViewportConfiguration.cadHighQuality
+        #expect(config.renderingQuality == .enhanced)
+        #expect(config.adaptiveTessellation == true)
+        #expect(config.tessellationMaxFactor >= 32)
+        // Plain .cad stays on the cheaper standard path (no auto-tessellation).
+        #expect(ViewportConfiguration.cad.renderingQuality == .standard)
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.5] — 2026-06-06
+
+### Added
+- **`ViewportConfiguration.cadHighQuality` preset** (issue #48, part 1) — exposes the renderer's existing screen-space-adaptive PN-triangle (Phong) tessellation for smooth round geometry. Sets `renderingQuality = .enhanced` + `adaptiveTessellation` + a higher `tessellationMaxFactor`, so curved surfaces (cylinder / cone silhouettes, fillets) stay smooth at any zoom without the consumer pre-tessellating finely. The smoothness counterpart to `.performance`.
+- **README "Smooth Round Geometry" section** — documents the surface-smoothness knobs (`renderingQuality`, `adaptiveTessellation`, `tessellationMaxFactor`, `NormalSmoothing`), the edge-sampling caveat, and the perf tradeoff.
+- Config preset test (114 total).
+
+Adaptive Phong tessellation already existed but was gated behind `.enhanced` (off by default); this makes it discoverable. Auto-smoothing flat input normals and analytic arc edges continue in #48.
+
 ## [1.1.4] — 2026-06-05
 
 ### Added


### PR DESCRIPTION
Part 1 of #48. **Key finding:** the renderer already has screen-space-adaptive PN-triangle (Phong) tessellation that smooths curved silhouettes — it was just gated behind `renderingQuality = .enhanced` (off by default), and no preset enabled it.

## Added
- **`ViewportConfiguration.cadHighQuality`** — enables `.enhanced` + `adaptiveTessellation` + `tessellationMaxFactor 48`. Curved surfaces (cylinder/cone silhouettes, fillets) stay smooth at any zoom, refined by projected size each frame — no consumer guessing a density. The smoothness counterpart to `.performance`.
- **README “Smooth Round Geometry”** — the surface knobs (`renderingQuality`/`adaptiveTessellation`/`tessellationMaxFactor`/`NormalSmoothing`), the polyline-edge caveat, and the perf tradeoff.
- Config test (114 total green).

## Notes
- Separate from `.cad` on purpose: tessellation adds GPU work, the opposite of the #42 perf direction, so the default stays cheap and this is opt-in.
- Requires Apple3+ GPU (falls back to un-tessellated). Needs reasonable per-vertex normals — OCCT meshes have them; flat meshes want `NormalSmoothing` first (→ #48 part 2).

Next in #48: auto-smooth flat normals (part 2), analytic arc edges (part 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)