### PR TITLE
feat(renderer): opt-in auto normal smoothing for tessellation (#48 part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,13 @@ let controller = ViewportController(configuration: .cadHighQuality)
 
 **What controls smoothness**
 - **Surfaces:** `renderingQuality = .enhanced` (or `.maximum`) enables adaptive
-  Phong tessellation. Requires an Apple3+ GPU (falls back gracefully). Needs
-  reasonable per-vertex normals on the input mesh — OCCT meshes provide these; for
-  flat-normalled meshes, run `NormalSmoothing.smoothNormals(vertexData:indices:creaseAngle:)`
-  first (crease-aware, so hard edges stay sharp).
+  Phong tessellation. Requires an Apple3+ GPU (falls back gracefully). Smooth
+  silhouettes need reasonable per-vertex normals — OCCT meshes provide these. For
+  flat / per-face-normalled meshes (e.g. STL), set `autoSmoothNormals = true`
+  (on by default in `.cadHighQuality`) and the renderer applies crease-aware
+  smoothing when building each body, so hard edges stay sharp (tune via
+  `normalSmoothingCreaseAngle`). You can also pre-smooth yourself with
+  `NormalSmoothing.smoothNormals(vertexData:indices:creaseAngle:)`.
 - **Feature edges:** edges are drawn as polylines, so a circular edge is only as
   smooth as its sampling. Sample BREP edges finely (e.g. 64+ points per circle)
   until analytic arc edges land — see [issue #48](https://github.com/gsdali/OCCTSwiftViewport/issues/48).

--- a/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+++ b/Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
@@ -142,6 +142,18 @@ public struct ViewportConfiguration: Sendable {
     /// culled by the camera frustum (off-screen casters can shadow visible geometry).
     public var enableFrustumCulling: Bool
 
+    /// Whether to apply crease-aware normal smoothing to each body's mesh when its
+    /// buffers are built (issue #48). Meshes that arrive with per-face (flat)
+    /// normals can't be rounded by Phong tessellation; smoothing averages normals
+    /// across shared vertices (preserving hard edges via the crease angle) so
+    /// `.enhanced` tessellation produces smooth silhouettes. Off by default —
+    /// enabled by `.cadHighQuality`. Computed once per body (cached), not per frame.
+    public var autoSmoothNormals: Bool
+
+    /// Crease angle (radians) for `autoSmoothNormals`: edges whose adjacent faces
+    /// differ by more than this stay sharp. Default ~30°.
+    public var normalSmoothingCreaseAngle: Float
+
     // MARK: - Picking
 
     /// Configuration for GPU-accelerated picking.
@@ -214,6 +226,8 @@ public struct ViewportConfiguration: Sendable {
         silhouetteThickness: Float = 1.0,
         silhouetteIntensity: Float = 0.7,
         enableFrustumCulling: Bool = true,
+        autoSmoothNormals: Bool = false,
+        normalSmoothingCreaseAngle: Float = 0.524,
         pickingConfiguration: PickingConfiguration = .init(),
         enableDepthOfField: Bool = false,
         dofAperture: Float = 2.8,
@@ -254,6 +268,8 @@ public struct ViewportConfiguration: Sendable {
         self.silhouetteThickness = silhouetteThickness
         self.silhouetteIntensity = silhouetteIntensity
         self.enableFrustumCulling = enableFrustumCulling
+        self.autoSmoothNormals = autoSmoothNormals
+        self.normalSmoothingCreaseAngle = normalSmoothingCreaseAngle
         self.pickingConfiguration = pickingConfiguration
         self.enableDepthOfField = enableDepthOfField
         self.dofAperture = dofAperture
@@ -340,6 +356,7 @@ public struct ViewportConfiguration: Sendable {
         showViewCube: true,
         showAxes: true,
         showGrid: true,
+        autoSmoothNormals: true,
         renderingQuality: .enhanced,
         tessellationMaxFactor: 48,
         adaptiveTessellation: true

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -2256,9 +2256,22 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         var vertexCount = 0
 
         if !body.vertexData.isEmpty, !body.indices.isEmpty {
+            // Optionally apply crease-aware normal smoothing (issue #48) so meshes
+            // with flat / per-face normals can be rounded by Phong tessellation.
+            // Done once here (generation-gated), and the tessellation patch builder
+            // reads from this vertex buffer, so smoothed normals flow into the
+            // PN-triangle control points automatically.
+            var meshVertexData = body.vertexData
+            if controller?.configuration.autoSmoothNormals == true {
+                NormalSmoothing.smoothNormals(
+                    vertexData: &meshVertexData,
+                    indices: body.indices,
+                    creaseAngle: controller?.configuration.normalSmoothingCreaseAngle ?? 0.524
+                )
+            }
             vertexBuffer = device.makeBuffer(
-                bytes: body.vertexData,
-                length: body.vertexData.count * MemoryLayout<Float>.size,
+                bytes: meshVertexData,
+                length: meshVertexData.count * MemoryLayout<Float>.size,
                 options: .storageModeShared
             )
             indexBuffer = device.makeBuffer(

--- a/Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift
+++ b/Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift
@@ -69,4 +69,46 @@ struct NormalSmoothingTests {
         #expect(abs(n1.x) < 1e-5)
         #expect(abs(n1.y) < 1e-5)
     }
+
+    // MARK: - Crease preservation (justifies auto-applying — #48 part 2)
+
+    /// Two triangles meeting at a 90° ridge along the shared y-axis edge. With a
+    /// crease angle below 90° the edge stays SHARP (each side keeps its own face
+    /// normal); with a crease angle above 90° the shared-edge normals average.
+    @Test("A hard crease is preserved below the crease angle, averaged above it")
+    func creasePreservedBelowAngle() {
+        // Two faces meeting at a 90° ridge along the shared edge (0,0,0)-(0,1,0):
+        // face A in the z=0 plane, face B in the x=0 plane. v0 (face A) and v3
+        // (face B) sit at the same position, so smoothing either splits them
+        // (sharp) or merges them (smooth) depending on the crease angle.
+        func build() -> [Float] {
+            interleaved([
+                SIMD3(0, 0, 0), SIMD3(0, 1, 0), SIMD3(1, 0, 0),   // face A
+                SIMD3(0, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1),   // face B
+            ])
+        }
+        let indices: [UInt32] = [0, 1, 2, 3, 4, 5]
+        func normal(_ d: [Float], _ v: Int) -> SIMD3<Float> {
+            SIMD3(d[v * 6 + 3], d[v * 6 + 4], d[v * 6 + 5])
+        }
+
+        // Sharp: 45° crease < 90° ridge → the shared-position normals stay split,
+        // each axis-aligned to its own face.
+        var sharp = build()
+        NormalSmoothing.smoothNormals(vertexData: &sharp, indices: indices, creaseAngle: .pi / 4)
+        let aSharp = normal(sharp, 0), bSharp = normal(sharp, 3)
+        #expect(simd_length(aSharp - bSharp) > 0.5)            // distinct (sharp)
+        #expect(abs(simd_length(aSharp) - 1) < 1e-4)           // unit, single-face
+        let aSharpComps = [abs(aSharp.x), abs(aSharp.y), abs(aSharp.z)].filter { $0 > 0.3 }
+        #expect(aSharpComps.count == 1)                        // axis-aligned
+
+        // Smooth: 120° crease > 90° ridge → both shared-position normals merge to
+        // the same blended (two-component) normal.
+        var smooth = build()
+        NormalSmoothing.smoothNormals(vertexData: &smooth, indices: indices, creaseAngle: 2.094)
+        let aSmooth = normal(smooth, 0), bSmooth = normal(smooth, 3)
+        #expect(simd_length(aSmooth - bSmooth) < 1e-3)         // merged (same normal)
+        let blendComps = [abs(aSmooth.x), abs(aSmooth.y), abs(aSmooth.z)].filter { $0 > 0.3 }
+        #expect(blendComps.count >= 2)                         // blended across faces
+    }
 }

--- a/Tests/OCCTSwiftViewportTests/ViewportConfigurationTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewportConfigurationTests.swift
@@ -29,4 +29,10 @@ struct ViewportConfigurationTests {
         // Plain .cad stays on the cheaper standard path (no auto-tessellation).
         #expect(ViewportConfiguration.cad.renderingQuality == .standard)
     }
+
+    @Test("cadHighQuality enables auto normal smoothing; default off (#48)")
+    func cadHighQualityAutoSmoothNormals() {
+        #expect(ViewportConfiguration.cadHighQuality.autoSmoothNormals == true)
+        #expect(ViewportConfiguration().autoSmoothNormals == false)
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.6] — 2026-06-06
+
+### Added
+- **Renderer-side auto normal smoothing** (issue #48, part 2) — `ViewportConfiguration.autoSmoothNormals` (+ `normalSmoothingCreaseAngle`). When enabled, the renderer applies crease-aware `NormalSmoothing` to each body's mesh as its buffers are built, so meshes that arrive with flat / per-face normals (e.g. STL) can actually be rounded by `.enhanced` Phong tessellation — hard edges stay sharp via the crease angle. Computed once per body (generation-gated, cached), and the smoothed normals flow into the tessellation patch control points automatically (the patch builder reads the body vertex buffer).
+- Enabled by default in `.cadHighQuality`. New tests: config wiring + crease preservation (116 total).
+- README "Smooth Round Geometry" updated to point at `autoSmoothNormals`.
+
+Analytic arc edges continue in #48 (part 3).
+
 ## [1.1.5] — 2026-06-06
 
 ### Added


### PR DESCRIPTION
Part 2 of #48. Makes the smooth path work even when the input mesh has flat / per-face normals (e.g. STL) — Phong tessellation can only round a surface if the corner normals vary across it.

## Added
- **`ViewportConfiguration.autoSmoothNormals`** (+ `normalSmoothingCreaseAngle`). When on, the renderer applies the existing crease-aware `NormalSmoothing` to each body’s mesh as its buffers are built. Hard edges stay sharp (crease angle); curved faces get averaged normals so `.enhanced` tessellation rounds them.
- Enabled by default in **`.cadHighQuality`**.

## How it threads through
- Done once per body in `ensureBuffers` (generation-gated, cached) — not per frame.
- The tessellation patch builder reads the body vertex buffer, so smoothing the vertex data before upload feeds the smoothed normals straight into the PN-triangle control points. No extra plumbing.
- Off by default (preserves existing behaviour); meshlet/pick paths unaffected.

## Tests
- Config wiring (`autoSmoothNormals` on for `.cadHighQuality`, off by default).
- **Crease preservation**: a 90° ridge stays split below the crease angle and merges above it. 116/116 green.

Next in #48: analytic arc edges (part 3) — smooth feature edges independent of mesh density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)