### PR TITLE
feat(renderer): analytic arc edges, adaptive to zoom (#48 part 3, closes #48)

### DIFF
--- a/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/SpikeView.swift
+++ b/Examples/MetalDemo/Sources/OCCTSwiftMetalDemo/SpikeView.swift
@@ -65,6 +65,23 @@ struct SpikeView: View {
             ],
             color: SIMD4<Float>(1.0, 1.0, 0.0, 1.0)
         ),
+        // Analytic arc edge (issue #48): a smooth circle, tessellated adaptively
+        // by the renderer regardless of zoom.
+        ViewportBody(
+            id: "arc-circle",
+            vertexData: [],
+            indices: [],
+            edges: [],
+            arcs: [
+                ViewportArc.circle(
+                    center: SIMD3<Float>(0, 0.8, 0),
+                    radius: 2.4,
+                    xAxis: SIMD3<Float>(1, 0, 0),
+                    yAxis: SIMD3<Float>(0, 1, 0)
+                )
+            ],
+            color: SIMD4<Float>(1.0, 0.2, 0.1, 1.0)
+        ),
     ]
 
     /// CAD metadata for sub-body selection (populated by CADFileLoader or procedural primitives).

--- a/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+++ b/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
@@ -83,6 +83,8 @@ public typealias _ViewportController = ViewportController
 
 // Metal Renderer
 public typealias _ViewportBody = ViewportBody
+public typealias _ViewportArc = ViewportArc
+public typealias _ArcSampling = ArcSampling
 public typealias _BodyPrimitiveKind = BodyPrimitiveKind
 public typealias _RenderLayer = RenderLayer
 public typealias _PickLayer = PickLayer

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -297,6 +297,10 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
     /// to either `ViewportController.pickResult` or `widgetPickResult`.
     private var currentLayerMap: [String: PickLayer] = [:]
 
+    /// Reused buffer for per-frame adaptively-sampled analytic arc edges (issue
+    /// #48). Grown on demand; written CPU-side each frame.
+    private var arcLineBuffer: MTLBuffer?
+
     /// Most recent drawable size in pixels, updated each frame. Lets the view layer
     /// derive the point→pixel scale without `UIScreen`/`NSScreen` (works on
     /// iOS / macOS / visionOS alike).
@@ -1542,6 +1546,60 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             }
         }
 
+        // 3.35 Analytic arc edge pass (issue #48 part 3).
+        // Adaptively samples each visible body's `arcs` to line segments by their
+        // projected size, so circular feature edges stay smooth at any zoom
+        // independent of mesh density. Built once per frame into one reused buffer
+        // and drawn per body (so arcs inherit the body's transform / colour).
+        let arcBodies = frameVisibleBodies.filter { !$0.body.arcs.isEmpty }
+        if !arcBodies.isEmpty {
+            let vpSize = SIMD2<Float>(Float(w), Float(h))
+            var arcVerts: [Float] = []
+            var arcRanges: [(body: ViewportBody, objectIndex: UInt32, start: Int, count: Int)] = []
+            for entry in arcBodies {
+                // Match the edge-pass visibility rule: show feature edges when the
+                // display mode draws edges, or when the body is edge-only.
+                let bodyHasMesh = entry.buffers.indexCount > 0
+                guard displayMode.showsEdges || !bodyHasMesh else { continue }
+
+                let mvp = viewProjection * entry.body.transform
+                let startVert = arcVerts.count / 6
+                for arc in entry.body.arcs {
+                    let segs = ArcSampling.segmentCount(arc: arc, mvp: mvp, viewportSize: vpSize)
+                    var prev = arc.point(at: 0)
+                    for s in 1...segs {
+                        let cur = arc.point(at: Float(s) / Float(segs))
+                        arcVerts.append(contentsOf: [prev.x, prev.y, prev.z, 0, 0, 0,
+                                                     cur.x, cur.y, cur.z, 0, 0, 0])
+                        prev = cur
+                    }
+                }
+                let count = arcVerts.count / 6 - startVert
+                if count > 0 {
+                    arcRanges.append((entry.body, entry.objectIndex, startVert, count))
+                }
+            }
+
+            if !arcVerts.isEmpty,
+               let arcBuf = ensureArcBuffer(byteCount: arcVerts.count * MemoryLayout<Float>.size) {
+                arcVerts.withUnsafeBytes { raw in
+                    arcBuf.contents().copyMemory(from: raw.baseAddress!, byteCount: raw.count)
+                }
+                mainEncoder.setRenderPipelineState(wireframePipeline)
+                mainEncoder.setVertexBuffer(arcBuf, offset: 0, index: 0)
+                var uniforms = makeUniforms()
+                for r in arcRanges {
+                    let bodyHasMesh = (bodyBufferCache[r.body.id]?.indexCount ?? 0) > 0
+                    var arcBodyUniforms = BodyUniforms(body: r.body, objectIndex: r.objectIndex, isSelected: 0)
+                    if !bodyHasMesh { arcBodyUniforms.metallic = -1.0 }  // use body colour directly
+                    mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                    mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                    mainEncoder.setFragmentBytes(&arcBodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
+                    mainEncoder.drawPrimitives(type: .line, vertexStart: r.start, vertexCount: r.count)
+                }
+            }
+        }
+
         // 3.4 Point-cloud pass (issue #28).
         // Walks bodies whose primitiveKind is .point and draws their
         // `vertices` as MTL point primitives with a world-space radius
@@ -2243,6 +2301,13 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
 
     // MARK: - Buffer Management
 
+    /// Returns the reused arc-line buffer, growing it if needed.
+    private func ensureArcBuffer(byteCount: Int) -> MTLBuffer? {
+        if let b = arcLineBuffer, b.length >= byteCount { return b }
+        arcLineBuffer = device.makeBuffer(length: max(byteCount, 4096), options: .storageModeShared)
+        return arcLineBuffer
+    }
+
     private func ensureBuffers(for body: ViewportBody) {
         let currentGen = body.generation
         if let cachedGen = bodyGeneration[body.id], cachedGen == currentGen {
@@ -2364,8 +2429,9 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             pointColorVB = nil
         }
 
-        // Skip bodies with no renderable data at all
-        guard vertexBuffer != nil || edgeVB != nil || pointPositionVB != nil else { return }
+        // Skip bodies with no renderable data at all. Arc-only bodies have none of
+        // the baked buffers (arcs are sampled per-frame), so admit them too (#48).
+        guard vertexBuffer != nil || edgeVB != nil || pointPositionVB != nil || !body.arcs.isEmpty else { return }
 
         // Build tessellation patch data if tessellation is enabled
         var tessBuffers: TessellationBuffers?

--- a/Sources/OCCTSwiftViewport/Types/ViewportArc.swift
+++ b/Sources/OCCTSwiftViewport/Types/ViewportArc.swift
@@ -1,0 +1,114 @@
+// ViewportArc.swift
+// ViewportKit
+//
+// Analytic arc/circle feature edge, sampled to line segments adaptively by the
+// renderer (issue #48) so circular edges stay smooth at any zoom.
+
+import simd
+
+/// An analytic circular arc in body-local space.
+///
+/// Defined by a center, radius, and an in-plane orthonormal basis (`xAxis`,
+/// `yAxis`); a point at angle θ is
+/// `center + radius * (cos θ · xAxis + sin θ · yAxis)`. The renderer samples the
+/// arc to line segments adaptively to its projected size each frame, so a circle
+/// renders smooth regardless of zoom — no pre-faceting by the consumer.
+public struct ViewportArc: Sendable, Hashable {
+
+    /// Arc center (body-local space).
+    public var center: SIMD3<Float>
+
+    /// Arc radius.
+    public var radius: Float
+
+    /// Unit in-plane axis for angle 0.
+    public var xAxis: SIMD3<Float>
+
+    /// Unit in-plane axis for angle π/2 (with `xAxis`, spans the arc plane).
+    public var yAxis: SIMD3<Float>
+
+    /// Start angle in radians.
+    public var startAngle: Float
+
+    /// End angle in radians (`endAngle > startAngle` sweeps counter-clockwise in
+    /// the `xAxis`→`yAxis` plane).
+    public var endAngle: Float
+
+    public init(center: SIMD3<Float>,
+                radius: Float,
+                xAxis: SIMD3<Float>,
+                yAxis: SIMD3<Float>,
+                startAngle: Float = 0,
+                endAngle: Float = 2 * .pi) {
+        self.center = center
+        self.radius = radius
+        self.xAxis = xAxis
+        self.yAxis = yAxis
+        self.startAngle = startAngle
+        self.endAngle = endAngle
+    }
+
+    /// A full circle in the plane spanned by `xAxis`/`yAxis` (which should be unit
+    /// and orthogonal; their cross product is the circle's normal).
+    public static func circle(center: SIMD3<Float>,
+                              radius: Float,
+                              xAxis: SIMD3<Float>,
+                              yAxis: SIMD3<Float>) -> ViewportArc {
+        ViewportArc(center: center, radius: radius, xAxis: xAxis, yAxis: yAxis,
+                    startAngle: 0, endAngle: 2 * .pi)
+    }
+
+    /// The swept angle (always non-negative).
+    public var sweep: Float { abs(endAngle - startAngle) }
+
+    /// Point on the arc at parameter `t` in `[0, 1]` (local space).
+    public func point(at t: Float) -> SIMD3<Float> {
+        let theta = startAngle + (endAngle - startAngle) * t
+        return center + radius * (cos(theta) * xAxis + sin(theta) * yAxis)
+    }
+}
+
+/// Pure helpers for adaptively sampling `ViewportArc`s to line segments.
+public enum ArcSampling {
+
+    /// Number of line segments to draw the arc with, chosen so each segment is
+    /// roughly `targetPixels` long on screen.
+    ///
+    /// Estimates the arc's projected length by coarsely sampling and projecting
+    /// through `mvp` (model · view · projection), then divides by `targetPixels`.
+    /// Clamped to `[minSegments, maxSegments]` and to an angular ceiling so even a
+    /// tiny on-screen circle keeps a round-ish shape. Falls back to `maxSegments`
+    /// if the arc crosses behind the camera (`w <= 0`).
+    public static func segmentCount(arc: ViewportArc,
+                                    mvp: simd_float4x4,
+                                    viewportSize: SIMD2<Float>,
+                                    targetPixels: Float = 6,
+                                    minSegments: Int = 6,
+                                    maxSegments: Int = 512) -> Int {
+        let coarse = 8
+        var pixelLength: Float = 0
+        var prev: SIMD2<Float>? = nil
+        var behind = false
+        for i in 0...coarse {
+            let t = Float(i) / Float(coarse)
+            let local = arc.point(at: t)
+            let clip = mvp * SIMD4<Float>(local, 1)
+            if clip.w <= 1e-5 { behind = true; break }
+            let ndc = SIMD2<Float>(clip.x / clip.w, clip.y / clip.w)
+            let px = SIMD2<Float>((ndc.x * 0.5) * viewportSize.x,
+                                  (ndc.y * 0.5) * viewportSize.y)
+            if let p = prev { pixelLength += simd_length(px - p) }
+            prev = px
+        }
+
+        // Angular ceiling: at least one segment per ~12° keeps small circles round.
+        let angularMin = Int((arc.sweep / (Float.pi / 15)).rounded(.up))
+
+        if behind {
+            return max(minSegments, min(maxSegments, max(angularMin, maxSegments / 4)))
+        }
+        let byPixels = Int((pixelLength / max(targetPixels, 0.5)).rounded(.up))
+        let n = max(minSegments, max(angularMin, byPixels))
+        return min(maxSegments, n)
+    }
+}

--- a/Sources/OCCTSwiftViewport/Types/ViewportBody.swift
+++ b/Sources/OCCTSwiftViewport/Types/ViewportBody.swift
@@ -86,6 +86,12 @@ public struct ViewportBody: Identifiable, Sendable {
     /// Polylines for wireframe rendering. Each inner array is a connected polyline.
     public var edges: [[SIMD3<Float>]]
 
+    /// Analytic arc/circle feature edges, in body-local space (issue #48). Unlike
+    /// `edges` (pre-sampled polylines), these are tessellated to line segments by
+    /// the renderer **adaptively to projected size each frame**, so they stay
+    /// smooth at any zoom independent of mesh density. Empty by default.
+    public var arcs: [ViewportArc]
+
     /// Per-triangle source face index. Parallel to triangle count (`indices.count / 3`).
     /// Maps each triangle back to its B-Rep face for sub-body selection. Empty if not applicable.
     public var faceIndices: [Int32]
@@ -171,6 +177,7 @@ public struct ViewportBody: Identifiable, Sendable {
         vertexData: [Float],
         indices: [UInt32],
         edges: [[SIMD3<Float>]],
+        arcs: [ViewportArc] = [],
         faceIndices: [Int32] = [],
         edgeIndices: [Int32] = [],
         vertices: [SIMD3<Float>] = [],
@@ -194,6 +201,7 @@ public struct ViewportBody: Identifiable, Sendable {
         self.vertexData = vertexData
         self.indices = indices
         self.edges = edges
+        self.arcs = arcs
         self.faceIndices = faceIndices
         self.edgeIndices = edgeIndices
         self.vertices = vertices

--- a/Tests/OCCTSwiftViewportTests/ViewportArcTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewportArcTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@Suite("Analytic arc edges")
+struct ViewportArcTests {
+
+    private static let unitCircle = ViewportArc.circle(
+        center: .zero, radius: 1,
+        xAxis: SIMD3(1, 0, 0), yAxis: SIMD3(0, 1, 0)
+    )
+
+    // MARK: - Arc evaluation
+
+    @Test("point(at:) walks the circle from xAxis through yAxis")
+    func pointEvaluation() {
+        let c = Self.unitCircle
+        let p0 = c.point(at: 0)
+        let pQuarter = c.point(at: 0.25)
+        let pHalf = c.point(at: 0.5)
+        #expect(simd_length(p0 - SIMD3<Float>(1, 0, 0)) < 1e-5)
+        #expect(simd_length(pQuarter - SIMD3<Float>(0, 1, 0)) < 1e-5)
+        #expect(simd_length(pHalf - SIMD3<Float>(-1, 0, 0)) < 1e-5)
+    }
+
+    @Test("A full circle sweeps 2π")
+    func fullCircleSweep() {
+        #expect(abs(Self.unitCircle.sweep - 2 * .pi) < 1e-5)
+    }
+
+    // MARK: - Adaptive segment count
+
+    @Test("Larger projected circles get more segments than smaller ones")
+    func segmentCountScalesWithProjectedSize() {
+        let vp = SIMD2<Float>(1000, 1000)
+        let mvp = matrix_identity_float4x4  // local x/y → NDC directly, w = 1
+
+        let big = ArcSampling.segmentCount(arc: Self.unitCircle, mvp: mvp, viewportSize: vp)
+        let small = ArcSampling.segmentCount(
+            arc: ViewportArc.circle(center: .zero, radius: 0.01,
+                                    xAxis: SIMD3(1, 0, 0), yAxis: SIMD3(0, 1, 0)),
+            mvp: mvp, viewportSize: vp
+        )
+        #expect(big > small)
+    }
+
+    @Test("Segment count honours min and max clamps")
+    func segmentCountClamps() {
+        let vp = SIMD2<Float>(4000, 4000)
+        // Huge projected circle → clamps to maxSegments.
+        let capped = ArcSampling.segmentCount(
+            arc: ViewportArc.circle(center: .zero, radius: 10,
+                                    xAxis: SIMD3(1, 0, 0), yAxis: SIMD3(0, 1, 0)),
+            mvp: matrix_identity_float4x4, viewportSize: vp,
+            maxSegments: 256
+        )
+        #expect(capped == 256)
+
+        // Tiny projected circle → at least minSegments.
+        let floored = ArcSampling.segmentCount(
+            arc: ViewportArc.circle(center: .zero, radius: 0.0001,
+                                    xAxis: SIMD3(1, 0, 0), yAxis: SIMD3(0, 1, 0)),
+            mvp: matrix_identity_float4x4, viewportSize: SIMD2(10, 10),
+            minSegments: 6
+        )
+        #expect(floored >= 6)
+    }
+
+    @Test("Behind-camera arcs fall back to a high segment count, never zero")
+    func behindCameraFallback() {
+        var mvp = matrix_identity_float4x4
+        mvp.columns.3 = SIMD4(0, 0, 0, -1)  // forces clip.w < 0 for all points
+        let n = ArcSampling.segmentCount(arc: Self.unitCircle, mvp: mvp,
+                                         viewportSize: SIMD2(1000, 1000), maxSegments: 512)
+        #expect(n >= 6)
+    }
+
+    // MARK: - Body integration
+
+    @Test("ViewportBody carries arcs; default is empty (source-compatible)")
+    func bodyArcsField() {
+        let plain = ViewportBody(id: "a", vertexData: [], indices: [], edges: [], color: .one)
+        #expect(plain.arcs.isEmpty)
+
+        let withArc = ViewportBody(id: "b", vertexData: [], indices: [], edges: [],
+                                   arcs: [Self.unitCircle], color: .one)
+        #expect(withArc.arcs.count == 1)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.7] — 2026-06-06
+
+### Added
+- **Analytic arc edges** (issue #48, part 3 — closes #48). New `ViewportArc` primitive (center / radius / in-plane basis / start+end angle) and `ViewportBody.arcs`. The renderer samples arcs to line segments **adaptively to their projected size each frame** (`ArcSampling.segmentCount`), so circular feature edges render smooth at any zoom, independent of mesh density — no consumer pre-faceting. Sampled once per frame into one reused buffer and drawn per body (inheriting transform / colour) through the existing wireframe pipeline. Re-exported as `_ViewportArc` / `_ArcSampling`.
+- Demo shows a smooth analytic circle.
+
+### Fixed
+- **Arc-only / data-light bodies were dropped by the renderer.** `ensureBuffers` skipped any body with no vertex/edge/point buffer, so a body carrying only `arcs` never reached the draw passes. The guard now also admits bodies with arcs. (Surfaced by on-device verification on the Vision Pro simulator.)
+
+### Tests
+- New `ViewportArcTests` (6): arc evaluation, adaptive segment count (scaling, clamps, behind-camera fallback), body integration. 122 total green; arc rendering confirmed on the Vision Pro simulator.
+
+With this, #48 is complete: `.cadHighQuality` adaptive surface tessellation (v1.1.5) + auto normal smoothing (v1.1.6) + analytic arc edges (v1.1.7).
+
 ## [1.1.6] — 2026-06-06
 
 ### Added


### PR DESCRIPTION
Part 3 of #48 — closes the issue. Smooth circular feature edges independent of mesh density.

## Added
- **`ViewportArc`** primitive (center / radius / in-plane basis / start+end angle) + **`ViewportBody.arcs`** (defaulted → source-compatible).
- The renderer samples arcs to line segments **adaptively to projected size each frame** (`ArcSampling.segmentCount`: projects a coarse sampling, divides by a target pixel length, clamps + angular floor + behind-camera fallback). A circle stays smooth at any zoom — no consumer pre-faceting, no wasted segments when small/distant.
- Sampled once per frame into one reused/grown buffer, drawn per body (inherits transform/colour) via the existing wireframe pipeline. Re-exported `_ViewportArc` / `_ArcSampling`.

## Fixed
- **Arc-only bodies were dropped:** `ensureBuffers` skipped any body with no vertex/edge/point buffer, so a body carrying only `arcs` never reached the draw passes. The guard now admits bodies with arcs. Found via on-device verification on the Vision Pro simulator (the arc didn’t render until this).

## Tests / verification
- `ViewportArcTests` (6): arc point evaluation, adaptive segment count (scales with size, min/max clamps, behind-camera fallback), body integration. **122/122 green.**
- Confirmed rendering a smooth circle on the Vision Pro simulator.

## Scope note
Arcs render (display) smoothly; arc **picking** isn’t wired yet (edges/arcs feed the line pass, not the pick texture) — a reasonable follow-up if needed.

#48 complete: adaptive surface tessellation preset (v1.1.5) + auto normal smoothing (v1.1.6) + analytic arc edges (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)