### PR TITLE
feat(picking): analytic arc picking (follow-up to #48)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
+++ b/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
@@ -525,6 +525,19 @@ fragment PickFragmentOut pick_line_fragment(
     return out;
 }
 
+// Analytic arc pick — kind=1 (edge). primitiveID is the ARC index, supplied per
+// draw (each arc is drawn separately), since the arc's segment count is sampled
+// adaptively per frame and `[[primitive_id]]` would only give a segment index.
+fragment PickFragmentOut pick_arc_fragment(
+    PickVertexOut in [[stage_in]],
+    constant BodyUniforms &bodyUniforms [[buffer(2)]],
+    constant uint &arcPrimID [[buffer(3)]]
+) {
+    PickFragmentOut out;
+    out.pickID = bodyUniforms.objectIndex | ((arcPrimID & 0x3FFFu) << 16) | (1u << 30);
+    return out;
+}
+
 // Point sprite vertex shader for vertex picking. Outputs `point_size` so
 // individual vertices have a clickable footprint instead of a single pixel.
 struct PickPointVertexOut {

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -194,6 +194,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
     /// Line-primitive pick pipeline for edge picking. Same vertex shader as
     /// `pick_vertex`; fragment emits kind=1 in the pick encoding.
     private let pickLinePipeline: MTLRenderPipelineState?
+    private let pickArcPipeline: MTLRenderPipelineState?
     /// Point-sprite pick pipeline for vertex picking. Vertex shader writes
     /// `[[point_size]]` so individual points have a clickable footprint;
     /// fragment emits kind=2.
@@ -474,6 +475,18 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         pickLineDesc.rasterSampleCount = 1
         pickLineDesc.vertexDescriptor = vertexDesc
         self.pickLinePipeline = try? device.makeRenderPipelineState(descriptor: pickLineDesc)
+
+        // 1x arc pick pipeline (issue #48) — reuses pick_vertex; fragment emits
+        // kind=1 with the per-draw arc index.
+        let pickArcDesc = MTLRenderPipelineDescriptor()
+        pickArcDesc.label = "pick_arc"
+        pickArcDesc.vertexFunction = library.makeFunction(name: "pick_vertex")
+        pickArcDesc.fragmentFunction = library.makeFunction(name: "pick_arc_fragment")
+        pickArcDesc.colorAttachments[0].pixelFormat = .r32Uint
+        pickArcDesc.depthAttachmentPixelFormat = .depth32Float
+        pickArcDesc.rasterSampleCount = 1
+        pickArcDesc.vertexDescriptor = vertexDesc
+        self.pickArcPipeline = try? device.makeRenderPipelineState(descriptor: pickArcDesc)
 
         // 1x point pick pipeline (vertex picking) — pick_point_vertex outputs
         // point_size for clickable footprint; fragment emits kind=2.
@@ -1546,16 +1559,17 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             }
         }
 
-        // 3.35 Analytic arc edge pass (issue #48 part 3).
+        // 3.35 Analytic arc edge pass (issue #48).
         // Adaptively samples each visible body's `arcs` to line segments by their
         // projected size, so circular feature edges stay smooth at any zoom
-        // independent of mesh density. Built once per frame into one reused buffer
-        // and drawn per body (so arcs inherit the body's transform / colour).
+        // independent of mesh density. Per-arc segment ranges are recorded in
+        // `frameArcDraws` and the data lives in `arcLineBuffer`, so the pick pass
+        // below re-draws the same segments to the pick texture without re-sampling.
+        var frameArcDraws: [(body: ViewportBody, objectIndex: UInt32, arcIndex: Int, start: Int, count: Int)] = []
         let arcBodies = frameVisibleBodies.filter { !$0.body.arcs.isEmpty }
         if !arcBodies.isEmpty {
             let vpSize = SIMD2<Float>(Float(w), Float(h))
             var arcVerts: [Float] = []
-            var arcRanges: [(body: ViewportBody, objectIndex: UInt32, start: Int, count: Int)] = []
             for entry in arcBodies {
                 // Match the edge-pass visibility rule: show feature edges when the
                 // display mode draws edges, or when the body is edge-only.
@@ -1563,9 +1577,9 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 guard displayMode.showsEdges || !bodyHasMesh else { continue }
 
                 let mvp = viewProjection * entry.body.transform
-                let startVert = arcVerts.count / 6
-                for arc in entry.body.arcs {
+                for (arcIndex, arc) in entry.body.arcs.enumerated() {
                     let segs = ArcSampling.segmentCount(arc: arc, mvp: mvp, viewportSize: vpSize)
+                    let startVert = arcVerts.count / 6
                     var prev = arc.point(at: 0)
                     for s in 1...segs {
                         let cur = arc.point(at: Float(s) / Float(segs))
@@ -1573,10 +1587,10 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                                                      cur.x, cur.y, cur.z, 0, 0, 0])
                         prev = cur
                     }
-                }
-                let count = arcVerts.count / 6 - startVert
-                if count > 0 {
-                    arcRanges.append((entry.body, entry.objectIndex, startVert, count))
+                    let count = arcVerts.count / 6 - startVert
+                    if count > 0 {
+                        frameArcDraws.append((entry.body, entry.objectIndex, arcIndex, startVert, count))
+                    }
                 }
             }
 
@@ -1587,15 +1601,16 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 }
                 mainEncoder.setRenderPipelineState(wireframePipeline)
                 mainEncoder.setVertexBuffer(arcBuf, offset: 0, index: 0)
-                var uniforms = makeUniforms()
-                for r in arcRanges {
-                    let bodyHasMesh = (bodyBufferCache[r.body.id]?.indexCount ?? 0) > 0
-                    var arcBodyUniforms = BodyUniforms(body: r.body, objectIndex: r.objectIndex, isSelected: 0)
+                for d in frameArcDraws {
+                    let bodyHasMesh = (bodyBufferCache[d.body.id]?.indexCount ?? 0) > 0
+                    var uniforms = makeUniforms()
+                    uniforms.modelMatrix = d.body.transform
+                    var arcBodyUniforms = BodyUniforms(body: d.body, objectIndex: d.objectIndex, isSelected: 0)
                     if !bodyHasMesh { arcBodyUniforms.metallic = -1.0 }  // use body colour directly
                     mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
                     mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
                     mainEncoder.setFragmentBytes(&arcBodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
-                    mainEncoder.drawPrimitives(type: .line, vertexStart: r.start, vertexCount: r.count)
+                    mainEncoder.drawPrimitives(type: .line, vertexStart: d.start, vertexCount: d.count)
                 }
             }
         }
@@ -1904,6 +1919,26 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                                     vertexCount: buffers.edgeVertexCount
                                 )
                             }
+                        }
+                    }
+
+                    // Arc pick pass (issue #48): re-draw this frame's adaptively
+                    // sampled arc segments (from `arcLineBuffer`, ranges in
+                    // `frameArcDraws`) to the pick texture. Each arc is drawn
+                    // separately so the fragment can stamp the ARC index (kind=1).
+                    if let pickArcPipeline, !frameArcDraws.isEmpty, let arcBuf = arcLineBuffer {
+                        pickEncoder.setDepthStencilState(pickEdgeOrPointDepthState)
+                        pickEncoder.setRenderPipelineState(pickArcPipeline)
+                        pickEncoder.setVertexBuffer(arcBuf, offset: 0, index: 0)
+                        for d in frameArcDraws {
+                            var uniforms = makeUniforms()
+                            uniforms.modelMatrix = d.body.transform
+                            var bodyUniforms = BodyUniforms(body: d.body, objectIndex: d.objectIndex)
+                            var arcPrimID = UInt32(truncatingIfNeeded: d.arcIndex)
+                            pickEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                            pickEncoder.setFragmentBytes(&bodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
+                            pickEncoder.setFragmentBytes(&arcPrimID, length: MemoryLayout<UInt32>.size, index: 3)
+                            pickEncoder.drawPrimitives(type: .line, vertexStart: d.start, vertexCount: d.count)
                         }
                     }
 

--- a/Sources/OCCTSwiftViewport/Types/ViewportArc.swift
+++ b/Sources/OCCTSwiftViewport/Types/ViewportArc.swift
@@ -13,6 +13,11 @@ import simd
 /// `center + radius * (cos θ · xAxis + sin θ · yAxis)`. The renderer samples the
 /// arc to line segments adaptively to its projected size each frame, so a circle
 /// renders smooth regardless of zoom — no pre-faceting by the consumer.
+///
+/// **Picking:** arcs are pickable. A hit reports `PickResult.kind == .edge` with
+/// `triangleIndex` equal to the arc's index within `ViewportBody.arcs`. (A body
+/// mixing polyline `edges` and `arcs` can't tell them apart from `kind` alone —
+/// prefer one representation per body.)
 public struct ViewportArc: Sendable, Hashable {
 
     /// Arc center (body-local space).

--- a/Tests/OCCTSwiftViewportTests/ViewportArcTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewportArcTests.swift
@@ -86,4 +86,18 @@ struct ViewportArcTests {
                                    arcs: [Self.unitCircle], color: .one)
         #expect(withArc.arcs.count == 1)
     }
+
+    // MARK: - Pick decode contract (arc → kind=.edge, primitiveID = arc index)
+
+    @Test("Arc pick value decodes to .edge with the arc index as triangleIndex")
+    func arcPickDecode() {
+        // The arc pick fragment emits objectIndex | (arcIndex << 16) | (1 << 30).
+        let objectIndex: UInt32 = 7
+        let arcIndex: UInt32 = 3
+        let raw = objectIndex | ((arcIndex & 0x3FFF) << 16) | (1 << 30)
+        let result = PickResult(rawValue: raw, indexMap: [7: "ring"])
+        #expect(result?.bodyID == "ring")
+        #expect(result?.kind == .edge)
+        #expect(result?.triangleIndex == Int(arcIndex))   // arc index
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.8] — 2026-06-06
+
+### Added
+- **Analytic arc picking** (follow-up to #48). `ViewportArc`s are now pickable: a hit reports `PickResult.kind == .edge` with `triangleIndex` = the arc's index in `ViewportBody.arcs`. The pick pass re-draws this frame's adaptively-sampled arc segments (reusing the display pass's buffer + ranges — no re-sampling) through a new `pick_arc` pipeline; because segment counts are per-frame adaptive, each arc is drawn separately and a `pick_arc_fragment` stamps the arc index (rather than `[[primitive_id]]`).
+- Fixes a latent bug found while wiring this: the arc *display* pass set the model matrix once (identity) instead of per body, so arcs on a transformed body drew at the wrong place; now set per draw.
+- New pick-decode contract test (123 total). Builds + runs on the Vision Pro simulator with the pick pass active.
+
+### Note
+- A body mixing polyline `edges` and `arcs` reports both as `kind == .edge`; `kind` alone can't disambiguate — prefer one edge representation per body.
+
 ## [1.1.7] — 2026-06-06
 
 ### Added


### PR DESCRIPTION
Wires up picking for the analytic arc edges added in v1.1.7 — the follow-up flagged on #48.

## What
- `ViewportArc`s are pickable: a hit returns `PickResult.kind == .edge` with `triangleIndex` = the arc index in `ViewportBody.arcs`.
- New `pick_arc` pipeline + `pick_arc_fragment`. The pick pass **re-draws this frame’s adaptively-sampled arc segments** — reusing the display pass’s buffer and per-arc ranges (`frameArcDraws`), so no re-sampling. Each arc is drawn separately and the fragment stamps the **arc index** (segment counts are per-frame adaptive, so `[[primitive_id]]` would only yield a segment index).
- Mirrors the proven edge-pick sub-pass (`.lessEqual` depth so arcs win over coplanar faces).

## Also fixed
- The arc **display** pass set `uniforms.modelMatrix` once (identity) instead of per body — arcs on a transformed body drew at the wrong place. Now set per draw (caught while adding the per-body pick draws).

## Verification
- Pick-decode contract test (arc → `.edge` + arc index). **123/123 green.**
- Builds + runs on the Vision Pro simulator with the pick pass active each frame (no regression; arc still renders).
- Interactive tap-to-pick is best confirmed on device/sim by hand (a synthetic spatial tap + `pickResult` readback isn’t scriptable from here).

## Note
A body mixing polyline `edges` and `arcs` reports both as `.edge`; `kind` alone can’t disambiguate — prefer one edge representation per body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)