### PR TITLE
feat(renderer): per-body surface transparency (closes #53)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
@@ -122,6 +122,7 @@ public final class OffscreenRenderer: Sendable {
     private let shadowPipeline: MTLRenderPipelineState
     private let shadowMapManager: ShadowMapManager
     private let depthState: MTLDepthStencilState
+    private let transparentDepthState: MTLDepthStencilState
     private let matcapTexture: MTLTexture
     private let axisVertexBuffer: MTLBuffer
 
@@ -179,6 +180,12 @@ public final class OffscreenRenderer: Sendable {
         shadedDesc.fragmentFunction = library.makeFunction(name: "shaded_fragment")
         shadedDesc.colorAttachments[0].pixelFormat = .bgra8Unorm
         shadedDesc.colorAttachments[1].pixelFormat = .invalid
+        // Per-body surface transparency (issue #53); opaque (alpha=1) unaffected.
+        shadedDesc.colorAttachments[0].isBlendingEnabled = true
+        shadedDesc.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+        shadedDesc.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+        shadedDesc.colorAttachments[0].sourceAlphaBlendFactor = .sourceAlpha
+        shadedDesc.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
         shadedDesc.depthAttachmentPixelFormat = depthFormat
         shadedDesc.stencilAttachmentPixelFormat = depthFormat
         shadedDesc.rasterSampleCount = sampleCount
@@ -279,6 +286,13 @@ public final class OffscreenRenderer: Sendable {
         depthDesc.isDepthWriteEnabled = true
         guard let depthState = device.makeDepthStencilState(descriptor: depthDesc) else { return nil }
         self.depthState = depthState
+
+        // Transparent surface depth state (#53): test on, write off.
+        let transparentDepthDesc = MTLDepthStencilDescriptor()
+        transparentDepthDesc.depthCompareFunction = .less
+        transparentDepthDesc.isDepthWriteEnabled = false
+        guard let transparentDepthState = device.makeDepthStencilState(descriptor: transparentDepthDesc) else { return nil }
+        self.transparentDepthState = transparentDepthState
 
         // Axis vertex buffer
         let axisLength: Float = 1000.0
@@ -511,16 +525,25 @@ public final class OffscreenRenderer: Sendable {
 
         // Bodies
         let displayMode = options.displayMode
+        // Translucent bodies (issue #53) are deferred to a sorted back-to-front pass.
+        var transparentBodies: [(body: ViewportBody, buffers: BodyBuffersOffscreen)] = []
         for body in bodies where body.isVisible {
             guard let buffers = bodyBufferCache[body.id] else { continue }
             // Point-cloud bodies are drawn in the dedicated pass below — skip
             // the mesh + wireframe paths entirely.
             if body.primitiveKind == .point { continue }
 
+            let hasMesh = buffers.vertexBuffer != nil && buffers.indexBuffer != nil && buffers.indexCount > 0
+
+            // Defer translucent mesh bodies to the transparent pass.
+            if body.renderLayer == .geometry, body.effectiveMaterial.opacity < 1.0, hasMesh {
+                transparentBodies.append((body, buffers))
+                continue
+            }
+
             var uniforms = makeUniforms()
             var bodyUniforms = BodyUniforms(body: body, objectIndex: 0, isSelected: 0)
 
-            let hasMesh = buffers.vertexBuffer != nil && buffers.indexBuffer != nil && buffers.indexCount > 0
             let hasEdges = buffers.edgeVertexBuffer != nil && buffers.edgeVertexCount > 0
 
             // Shaded
@@ -548,6 +571,37 @@ public final class OffscreenRenderer: Sendable {
                 mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
                 mainEncoder.setFragmentBytes(&edgeBodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
                 mainEncoder.drawPrimitives(type: .line, vertexStart: 0, vertexCount: buffers.edgeVertexCount)
+            }
+        }
+
+        // Transparent surface pass (issue #53): deferred translucent bodies,
+        // back-to-front, depth test on / write off, composited over the opaque set.
+        if displayMode.showsSurfaces, !transparentBodies.isEmpty {
+            let camPos = cameraState.position
+            func centerDistanceSq(_ t: (body: ViewportBody, buffers: BodyBuffersOffscreen)) -> Float {
+                let localCenter = t.body.boundingBox?.center ?? SIMD3<Float>(0, 0, 0)
+                let c = t.body.transform * SIMD4<Float>(localCenter, 1)
+                return simd_length_squared(SIMD3<Float>(c.x, c.y, c.z) - camPos)
+            }
+            let sorted = transparentBodies.sorted { centerDistanceSq($0) > centerDistanceSq($1) }
+
+            mainEncoder.setDepthStencilState(transparentDepthState)
+            mainEncoder.setRenderPipelineState(shadedPipeline)
+            mainEncoder.setFragmentTexture(matcapTexture, index: 0)
+            if shadowEnabled, let shadowTex = shadowMapManager.texture {
+                mainEncoder.setFragmentTexture(shadowTex, index: 1)
+            }
+            for t in sorted {
+                guard let vb = t.buffers.vertexBuffer, let ib = t.buffers.indexBuffer,
+                      t.buffers.indexCount > 0 else { continue }
+                var uniforms = makeUniforms()
+                var bodyUniforms = BodyUniforms(body: t.body, objectIndex: 0, isSelected: 0)
+                mainEncoder.setVertexBuffer(vb, offset: 0, index: 0)
+                mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                mainEncoder.setFragmentBytes(&bodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
+                mainEncoder.drawIndexedPrimitives(type: .triangle, indexCount: t.buffers.indexCount,
+                                                  indexType: .uint32, indexBuffer: ib, indexBufferOffset: 0)
             }
         }
 

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -230,6 +230,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
     // Identical-position highlight triangles win ties with the shaded pass
     // without depth-fighting; depth write off so later passes aren't disturbed.
     private let highlightDepthState: MTLDepthStencilState
+    private let transparentSurfaceDepthState: MTLDepthStencilState
     private let matcapTexture: MTLTexture
     private let msaaSampleCount: Int
     // Skybox (HDR background draw — IBL cubemap as fullscreen background)
@@ -357,6 +358,13 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         shadedDesc.fragmentFunction = library.makeFunction(name: "shaded_fragment")
         shadedDesc.colorAttachments[0].pixelFormat = .bgra8Unorm
         shadedDesc.colorAttachments[1].pixelFormat = .invalid
+        // Per-body surface transparency (issue #53): honour bodyUniforms.color.a.
+        // Opaque bodies (alpha = 1) are unchanged by src-alpha / 1-src-alpha blending.
+        shadedDesc.colorAttachments[0].isBlendingEnabled = true
+        shadedDesc.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+        shadedDesc.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+        shadedDesc.colorAttachments[0].sourceAlphaBlendFactor = .sourceAlpha
+        shadedDesc.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
         shadedDesc.depthAttachmentPixelFormat = depthFormat
         shadedDesc.stencilAttachmentPixelFormat = depthFormat
         shadedDesc.rasterSampleCount = sampleCount
@@ -617,6 +625,12 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             tsDesc.fragmentFunction = library.makeFunction(name: "shaded_fragment")
             tsDesc.colorAttachments[0].pixelFormat = .bgra8Unorm
             tsDesc.colorAttachments[1].pixelFormat = .invalid
+            // Per-body surface transparency (issue #53).
+            tsDesc.colorAttachments[0].isBlendingEnabled = true
+            tsDesc.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+            tsDesc.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+            tsDesc.colorAttachments[0].sourceAlphaBlendFactor = .sourceAlpha
+            tsDesc.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
             tsDesc.depthAttachmentPixelFormat = depthFormat
             tsDesc.stencilAttachmentPixelFormat = depthFormat
             tsDesc.rasterSampleCount = sampleCount
@@ -721,6 +735,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 depthFmt: MTLPixelFormat,
                 stencilFmt: MTLPixelFormat = .invalid,
                 samples: Int = 1,
+                blend: Bool = false,
                 label: String
             ) -> MTLRenderPipelineState? {
                 let desc = MTLMeshRenderPipelineDescriptor()
@@ -730,6 +745,14 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 desc.fragmentFunction = fragmentFn
                 if colorFormat != .invalid {
                     desc.colorAttachments[0].pixelFormat = colorFormat
+                    if blend {
+                        // Per-body surface transparency (issue #53).
+                        desc.colorAttachments[0].isBlendingEnabled = true
+                        desc.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
+                        desc.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
+                        desc.colorAttachments[0].sourceAlphaBlendFactor = .sourceAlpha
+                        desc.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
+                    }
                 }
                 desc.depthAttachmentPixelFormat = depthFmt
                 if stencilFmt != .invalid {
@@ -748,7 +771,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             self.meshShaderShadedPipeline = makeMeshPipeline(
                 meshFn: meshFunc, fragmentFn: shadedFrag,
                 colorFormat: .bgra8Unorm, depthFmt: depthFormat, stencilFmt: depthFormat,
-                samples: sampleCount, label: "mesh_shaded"
+                samples: sampleCount, blend: true, label: "mesh_shaded"
             )
             self.meshShaderShadowPipeline = makeMeshPipeline(
                 meshFn: shadowMeshFunc, fragmentFn: depthFrag,
@@ -868,6 +891,18 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             return nil
         }
         self.highlightDepthState = highlightDepthState
+
+        // .less + write disabled — for the transparent surface pass (issue #53).
+        // Transparent bodies test against the opaque depth buffer (so they hide
+        // behind opaque geometry) but don't write depth, so back-to-front sorted
+        // translucent surfaces composite without occluding each other in depth.
+        let transparentDepthDesc = MTLDepthStencilDescriptor()
+        transparentDepthDesc.depthCompareFunction = .less
+        transparentDepthDesc.isDepthWriteEnabled = false
+        guard let transparentSurfaceDepthState = device.makeDepthStencilState(descriptor: transparentDepthDesc) else {
+            return nil
+        }
+        self.transparentSurfaceDepthState = transparentSurfaceDepthState
 
         // Build axis vertex buffer (6 vertices for 3 lines)
         let axisLength: Float = 1000.0
@@ -1450,6 +1485,10 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         let selectedIDs = controller.selectedBodyIDs
         let hoveredID = controller.hoveredBodyID
 
+        // Transparent surfaces (issue #53) are deferred to a sorted back-to-front
+        // pass after the opaque bodies, so they composite correctly.
+        var transparentDraws: [(body: ViewportBody, buffers: BodyBuffers, objectIndex: UInt32)] = []
+
         for (body, buffers, bodyObjectIndex) in frameVisibleBodies {
             // Frustum-cull off-screen geometry inline using the cached local AABB.
             // Pick IDs stay stable: bodyObjectIndex was assigned over all visible
@@ -1465,6 +1504,14 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             // below — skip the mesh + wireframe paths so a `.point` body that
             // happens to also carry stray vertexData/edges doesn't double-draw.
             if body.primitiveKind == .point { continue }
+            // Translucent geometry bodies are deferred to the sorted transparent
+            // pass below (a body with edges only — no mesh — is unaffected).
+            if body.renderLayer == .geometry,
+               body.effectiveMaterial.opacity < 1.0,
+               buffers.vertexBuffer != nil, buffers.indexCount > 0 {
+                transparentDraws.append((body, buffers, bodyObjectIndex))
+                continue
+            }
 
             var uniforms = makeUniforms()
             uniforms.modelMatrix = body.transform
@@ -1476,8 +1523,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             let hasEdges = buffers.edgeVertexBuffer != nil && buffers.edgeVertexCount > 0
 
             // Shaded pass (mesh bodies only)
-            if displayMode.showsSurfaces, hasMesh,
-               let vb = buffers.vertexBuffer, let ib = buffers.indexBuffer {
+            if displayMode.showsSurfaces, hasMesh {
                 // Write stencil=1 for selected bodies
                 if selState > 0 {
                     mainEncoder.setDepthStencilState(stencilWriteState)
@@ -1499,46 +1545,8 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                     if let brdf = envMgr.brdfLUT { mainEncoder.setFragmentTexture(brdf, index: 4) }
                 }
 
-                if useMeshShaders, let ml = buffers.meshlets, let msPipeline = meshShaderShadedPipeline {
-                    mainEncoder.setRenderPipelineState(msPipeline)
-                    mainEncoder.setObjectBuffer(ml.descriptorBuffer, offset: 0, index: 0)
-                    mainEncoder.setObjectBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
-                    mainEncoder.setMeshBuffer(ml.descriptorBuffer, offset: 0, index: 0)
-                    mainEncoder.setMeshBuffer(vb, offset: 0, index: 1)
-                    mainEncoder.setMeshBuffer(ml.vertexIndexBuffer, offset: 0, index: 2)
-                    mainEncoder.setMeshBuffer(ml.triangleIndexBuffer, offset: 0, index: 3)
-                    mainEncoder.setMeshBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 4)
-                    mainEncoder.drawMeshThreadgroups(
-                        MTLSize(width: ml.meshletCount, height: 1, depth: 1),
-                        threadsPerObjectThreadgroup: MTLSize(width: 1, height: 1, depth: 1),
-                        threadsPerMeshThreadgroup: MTLSize(width: 64, height: 1, depth: 1)
-                    )
-                } else if useTessellation, let tess = buffers.tessellation, let tessPipeline = tessellatedShadedPipeline {
-                    mainEncoder.setRenderPipelineState(tessPipeline)
-                    mainEncoder.setTessellationFactorBuffer(tess.tessFactorBuffer, offset: 0, instanceStride: 0)
-                    mainEncoder.setVertexBuffer(tess.patchDataBuffer, offset: 0, index: 0)
-                    mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
-                    mainEncoder.drawPatches(
-                        numberOfPatchControlPoints: 3,
-                        patchStart: 0,
-                        patchCount: tess.patchCount,
-                        patchIndexBuffer: nil,
-                        patchIndexBufferOffset: 0,
-                        instanceCount: 1,
-                        baseInstance: 0
-                    )
-                } else {
-                    mainEncoder.setRenderPipelineState(shadedPipeline)
-                    mainEncoder.setVertexBuffer(vb, offset: 0, index: 0)
-                    mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
-                    mainEncoder.drawIndexedPrimitives(
-                        type: .triangle,
-                        indexCount: buffers.indexCount,
-                        indexType: .uint32,
-                        indexBuffer: ib,
-                        indexBufferOffset: 0
-                    )
-                }
+                encodeShadedSurface(mainEncoder, buffers: buffers, uniforms: &uniforms,
+                                    useMeshShaders: useMeshShaders, useTessellation: useTessellation)
             }
 
             // Wireframe/edge pass
@@ -1556,6 +1564,39 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
                 mainEncoder.setFragmentBytes(&edgeBodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
                 mainEncoder.drawPrimitives(type: .line, vertexStart: 0, vertexCount: buffers.edgeVertexCount)
+            }
+        }
+
+        // 3.3 Transparent surface pass (issue #53): draw the deferred translucent
+        // bodies back-to-front with depth-test on / write off, so they composite
+        // over the opaque set (and over each other in sorted order).
+        if displayMode.showsSurfaces, !transparentDraws.isEmpty {
+            let camPos = cameraState.position
+            func centerDistanceSq(_ d: (body: ViewportBody, buffers: BodyBuffers, objectIndex: UInt32)) -> Float {
+                let localCenter = d.buffers.localBoundingBox?.center ?? SIMD3<Float>(0, 0, 0)
+                let c = d.body.transform * SIMD4<Float>(localCenter, 1)
+                return simd_length_squared(SIMD3<Float>(c.x, c.y, c.z) - camPos)
+            }
+            let sorted = transparentDraws.sorted { centerDistanceSq($0) > centerDistanceSq($1) }
+
+            mainEncoder.setDepthStencilState(transparentSurfaceDepthState)
+            mainEncoder.setFragmentTexture(matcapTexture, index: 0)
+            if shadowEnabled, let shadowTex = shadowMapManager.texture {
+                mainEncoder.setFragmentTexture(shadowTex, index: 1)
+            }
+            if let envMgr = environmentMapManager, envMgr.hasEnvironmentMap {
+                if let spec = envMgr.prefilteredSpecularMap { mainEncoder.setFragmentTexture(spec, index: 2) }
+                if let diff = envMgr.irradianceMap { mainEncoder.setFragmentTexture(diff, index: 3) }
+                if let brdf = envMgr.brdfLUT { mainEncoder.setFragmentTexture(brdf, index: 4) }
+            }
+            for d in sorted {
+                var uniforms = makeUniforms()
+                uniforms.modelMatrix = d.body.transform
+                var bodyUniforms = BodyUniforms(body: d.body, objectIndex: d.objectIndex, isSelected: 0)
+                mainEncoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+                mainEncoder.setFragmentBytes(&bodyUniforms, length: MemoryLayout<BodyUniforms>.size, index: 2)
+                encodeShadedSurface(mainEncoder, buffers: d.buffers, uniforms: &uniforms,
+                                    useMeshShaders: useMeshShaders, useTessellation: useTessellation)
             }
         }
 
@@ -2332,6 +2373,62 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         )
 
         return lightProj * lightView
+    }
+
+    // MARK: - Shaded surface draw
+
+    /// Encodes a body's shaded surface via the mesh-shader, tessellated, or
+    /// standard path. The caller sets uniforms / fragment bytes / textures / depth
+    /// state first. Shared by the opaque main loop and the transparent pass (#53).
+    private func encodeShadedSurface(
+        _ encoder: MTLRenderCommandEncoder,
+        buffers: BodyBuffers,
+        uniforms: inout Uniforms,
+        useMeshShaders: Bool,
+        useTessellation: Bool
+    ) {
+        guard let vb = buffers.vertexBuffer, let ib = buffers.indexBuffer, buffers.indexCount > 0 else { return }
+
+        if useMeshShaders, let ml = buffers.meshlets, let msPipeline = meshShaderShadedPipeline {
+            encoder.setRenderPipelineState(msPipeline)
+            encoder.setObjectBuffer(ml.descriptorBuffer, offset: 0, index: 0)
+            encoder.setObjectBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+            encoder.setMeshBuffer(ml.descriptorBuffer, offset: 0, index: 0)
+            encoder.setMeshBuffer(vb, offset: 0, index: 1)
+            encoder.setMeshBuffer(ml.vertexIndexBuffer, offset: 0, index: 2)
+            encoder.setMeshBuffer(ml.triangleIndexBuffer, offset: 0, index: 3)
+            encoder.setMeshBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 4)
+            encoder.drawMeshThreadgroups(
+                MTLSize(width: ml.meshletCount, height: 1, depth: 1),
+                threadsPerObjectThreadgroup: MTLSize(width: 1, height: 1, depth: 1),
+                threadsPerMeshThreadgroup: MTLSize(width: 64, height: 1, depth: 1)
+            )
+        } else if useTessellation, let tess = buffers.tessellation, let tessPipeline = tessellatedShadedPipeline {
+            encoder.setRenderPipelineState(tessPipeline)
+            encoder.setTessellationFactorBuffer(tess.tessFactorBuffer, offset: 0, instanceStride: 0)
+            encoder.setVertexBuffer(tess.patchDataBuffer, offset: 0, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+            encoder.drawPatches(
+                numberOfPatchControlPoints: 3,
+                patchStart: 0,
+                patchCount: tess.patchCount,
+                patchIndexBuffer: nil,
+                patchIndexBufferOffset: 0,
+                instanceCount: 1,
+                baseInstance: 0
+            )
+        } else {
+            encoder.setRenderPipelineState(shadedPipeline)
+            encoder.setVertexBuffer(vb, offset: 0, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
+            encoder.drawIndexedPrimitives(
+                type: .triangle,
+                indexCount: buffers.indexCount,
+                indexType: .uint32,
+                indexBuffer: ib,
+                indexBufferOffset: 0
+            )
+        }
     }
 
     // MARK: - Buffer Management

--- a/Tests/OCCTSwiftViewportTests/SurfaceTransparencyTests.swift
+++ b/Tests/OCCTSwiftViewportTests/SurfaceTransparencyTests.swift
@@ -1,0 +1,110 @@
+// SurfaceTransparencyTests.swift
+// OCCTSwiftViewport Tests
+//
+// Per-body surface transparency (issue #53). Differential headless render:
+// the same scene with the front box opaque vs translucent — the translucent
+// render must reveal more of the opaque red box behind it.
+
+import Testing
+import simd
+import CoreGraphics
+@testable import OCCTSwiftViewport
+
+@MainActor
+@Suite("Surface transparency")
+struct SurfaceTransparencyTests {
+
+    // Camera at +Z (identity rotation) looking down -Z at the origin, so a larger
+    // +Z offset is nearer the camera.
+    private let camera = CameraState(
+        rotation: simd_quatf(angle: 0, axis: SIMD3<Float>(0, 0, 1)),
+        distance: 10,
+        pivot: .zero
+    )
+
+    /// A flat quad at depth `z` facing +Z (toward the camera). Positions are baked
+    /// into the geometry because `OffscreenRenderer` doesn't apply `body.transform`.
+    private func panel(id: String, z: Float, half: Float, color: SIMD4<Float>) -> ViewportBody {
+        func v(_ x: Float, _ y: Float) -> [Float] { [x, y, z, 0, 0, 1] }
+        let verts = v(-half, -half) + v(half, -half) + v(half, half) + v(-half, half)
+        let idx: [UInt32] = [0, 1, 2, 0, 2, 3]
+        return ViewportBody(id: id, vertexData: verts, indices: idx, edges: [], color: color)
+    }
+
+    /// Red opaque box at the origin, with a large blue panel baked in front of it
+    /// (toward the camera at +Z) that fully covers it in screen space.
+    private func scene(blueAlpha: Float) -> [ViewportBody] {
+        let red = ViewportBody.box(id: "red", width: 2, height: 2, depth: 2,
+                                   color: SIMD4<Float>(1, 0, 0, 1))
+        let blue = panel(id: "blue", z: 3, half: 3, color: SIMD4<Float>(0, 0, 1, blueAlpha))
+        return [red, blue]
+    }
+
+    @Test("Translucent front body reveals the opaque body behind it (#53)")
+    func translucentRevealsBehind() throws {
+        guard let renderer = OffscreenRenderer() else {
+            Issue.record("Metal device unavailable; skipping headless render test")
+            return
+        }
+        let opts = OffscreenRenderOptions(width: 200, height: 200, cameraState: camera,
+                                          backgroundColor: SIMD4<Float>(0, 0, 0, 1))
+
+        guard let opaqueImg = renderer.render(bodies: scene(blueAlpha: 1.0), options: opts),
+              let transImg = renderer.render(bodies: scene(blueAlpha: 0.3), options: opts) else {
+            Issue.record("renderer returned nil image")
+            return
+        }
+
+        // With an OPAQUE blue panel in front, the red box is hidden → almost no red.
+        // With a TRANSLUCENT panel, the red shows through → many red-bearing pixels.
+        let redOpaque = countRedBearingPixels(opaqueImg)
+        let redTrans = countRedBearingPixels(transImg)
+
+        #expect(redOpaque < 400,
+                "opaque front panel should hide the red box, got \(redOpaque) red pixels")
+        #expect(redTrans > redOpaque + 1000,
+                "translucent panel should reveal the red box behind; opaque=\(redOpaque) translucent=\(redTrans)")
+    }
+
+    // MARK: - Helpers
+
+    /// Pixels where the red channel is clearly present and not a white specular
+    /// highlight (red noticeably exceeds green).
+    private func countRedBearingPixels(_ image: CGImage) -> Int {
+        let (buffer, width, height) = readBGRA(image)
+        let bytesPerRow = width * 4
+        var count = 0
+        for y in 0..<height {
+            for x in 0..<width {
+                let i = y * bytesPerRow + x * 4
+                let b = Int(buffer[i])
+                let g = Int(buffer[i + 1])
+                let r = Int(buffer[i + 2])
+                _ = b
+                if r > 60 && r > g + 30 { count += 1 }
+            }
+        }
+        return count
+    }
+
+    private func readBGRA(_ image: CGImage) -> ([UInt8], Int, Int) {
+        let width = image.width
+        let height = image.height
+        let bytesPerRow = width * 4
+        var buffer = [UInt8](repeating: 0, count: bytesPerRow * height)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue:
+            CGImageAlphaInfo.premultipliedFirst.rawValue |
+            CGBitmapInfo.byteOrder32Little.rawValue)
+        buffer.withUnsafeMutableBytes { raw in
+            if let ctx = CGContext(
+                data: raw.baseAddress, width: width, height: height,
+                bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+                space: colorSpace, bitmapInfo: bitmapInfo.rawValue
+            ) {
+                ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            }
+        }
+        return (buffer, width, height)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.9] — 2026-06-06
+
+### Added
+- **Per-body surface transparency** (issue #53, closes it). A body with `color.w` / `effectiveMaterial.opacity` < 1 now renders as a translucent surface compositing over the geometry behind it — enabling "focus one part, fade the rest" interactions.
+  - Alpha blending (`.sourceAlpha` / `.oneMinusSourceAlpha`) enabled on all shaded pipelines (standard, tessellated, mesh-shader) in both `ViewportRenderer` and `OffscreenRenderer`. Opaque bodies (alpha = 1) are unaffected.
+  - Translucent bodies are drawn in a dedicated pass **after** the opaque set, sorted **back-to-front** by camera distance, with depth **test on / write off** (new `transparentSurfaceDepthState`), so they composite correctly without occluding each other in depth. Opaque bodies stay fully z-correct among themselves.
+  - Works headlessly in `OffscreenRenderer` (PNG) as well as live.
+  - New `SurfaceTransparencyTests` — a differential GPU render (opaque vs translucent front panel) asserting the body behind shows through (124 tests total). Live opaque rendering verified unchanged on the Vision Pro simulator.
+
+### Note
+- The alpha plumbing already existed end-to-end (`shaded_fragment` outputs `bodyUniforms.color.a`); only blending + draw order were missing.
+
 ## [1.1.8] — 2026-06-06
 
 ### Added


### PR DESCRIPTION
Closes #53.

Bodies with `color.w` / `effectiveMaterial.opacity` < 1 now render as translucent surfaces compositing over the geometry behind them — the “focus one part, fade the rest” use case.

## What
- **Alpha blending** (`.sourceAlpha` / `.oneMinusSourceAlpha`) enabled on all shaded pipelines (standard, tessellated, mesh-shader) in **both** `ViewportRenderer` and `OffscreenRenderer`. Opaque bodies (alpha = 1) are unaffected by the blend.
- **Sorted transparent pass:** translucent bodies are deferred and drawn after the opaque set, **back-to-front** by camera distance, with depth **test on / write off** (new `transparentSurfaceDepthState`). Opaque bodies remain fully z-correct among themselves; transparent surfaces composite without occluding each other in depth.
- Factored the shaded 3-path draw into `encodeShadedSurface()` shared by the opaque loop and the transparent pass.

The alpha plumbing already existed end-to-end (`shaded_fragment` outputs `bodyUniforms.color.a`); only blending + draw order were missing.

## Acceptance (all met)
- A body with `color.w = 0.3` renders translucent over the bodies behind it. ✅
- Opaque bodies unaffected / z-correct. ✅
- Works in `ViewportRenderer` (live) **and** `OffscreenRenderer` (headless PNG). ✅

## Tests / verification
- `SurfaceTransparencyTests`: a **differential GPU render** — same scene with an opaque vs translucent front panel; asserts the opaque panel hides the red box behind (<400 red px) while the translucent one reveals it (>+1000). **124/124 green.**
- Live opaque rendering verified unchanged on the Vision Pro simulator (the main-loop refactor is behaviour-preserving for opaque scenes).

## Note
While testing I confirmed `OffscreenRenderer` ignores per-body `transform` (modelMatrix is always identity) — a pre-existing limitation unrelated to transparency; the test bakes positions into geometry to work around it. Worth a separate issue if headless transforms are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)