### PR TITLE
fix(offscreen): honour per-body transform in headless renders (closes #55)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
@@ -463,7 +463,7 @@ public final class OffscreenRenderer: Sendable {
                         guard let buffers = bodyBufferCache[body.id],
                               let vb = buffers.vertexBuffer, let ib = buffers.indexBuffer,
                               buffers.indexCount > 0 else { continue }
-                        var shadowUniforms = ShadowUniformsSwift(lightViewProjectionMatrix: lightVP, modelMatrix: matrix_identity_float4x4)
+                        var shadowUniforms = ShadowUniformsSwift(lightViewProjectionMatrix: lightVP, modelMatrix: body.transform)
                         enc.setRenderPipelineState(shadowPipeline)
                         enc.setVertexBuffer(vb, offset: 0, index: 0)
                         enc.setVertexBytes(&shadowUniforms, length: MemoryLayout<ShadowUniformsSwift>.size, index: 1)
@@ -542,6 +542,7 @@ public final class OffscreenRenderer: Sendable {
             }
 
             var uniforms = makeUniforms()
+            uniforms.modelMatrix = body.transform
             var bodyUniforms = BodyUniforms(body: body, objectIndex: 0, isSelected: 0)
 
             let hasEdges = buffers.edgeVertexBuffer != nil && buffers.edgeVertexCount > 0
@@ -595,6 +596,7 @@ public final class OffscreenRenderer: Sendable {
                 guard let vb = t.buffers.vertexBuffer, let ib = t.buffers.indexBuffer,
                       t.buffers.indexCount > 0 else { continue }
                 var uniforms = makeUniforms()
+                uniforms.modelMatrix = t.body.transform
                 var bodyUniforms = BodyUniforms(body: t.body, objectIndex: 0, isSelected: 0)
                 mainEncoder.setVertexBuffer(vb, offset: 0, index: 0)
                 mainEncoder.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 1)
@@ -623,6 +625,7 @@ public final class OffscreenRenderer: Sendable {
                 }
 
                 var uniforms = makeUniforms()
+                uniforms.modelMatrix = body.transform
                 let useColors = (buffers.pointColorBuffer != nil) ? UInt32(1) : UInt32(0)
                 var params = PointParamsSwift(
                     baseColor: body.color,
@@ -820,7 +823,7 @@ public final class OffscreenRenderer: Sendable {
         var hasGeometry = false
 
         for body in bodies where body.isVisible {
-            if let bb = body.boundingBox {
+            if let bb = body.boundingBox?.transformed(by: body.transform) {
                 sceneMin = simd_min(sceneMin, bb.min)
                 sceneMax = simd_max(sceneMax, bb.max)
                 hasGeometry = true

--- a/Tests/OCCTSwiftViewportTests/OffscreenTransformTests.swift
+++ b/Tests/OCCTSwiftViewportTests/OffscreenTransformTests.swift
@@ -1,0 +1,124 @@
+// OffscreenTransformTests.swift
+// OCCTSwiftViewport Tests
+//
+// OffscreenRenderer now honours per-body `transform` (issue #55).
+
+import Testing
+import simd
+import CoreGraphics
+@testable import OCCTSwiftViewport
+
+@MainActor
+@Suite("OffscreenRenderer per-body transform")
+struct OffscreenTransformTests {
+
+    @Test("A body's transform offsets it in headless renders (#55)")
+    func transformOffsetsGeometry() throws {
+        guard let renderer = OffscreenRenderer() else {
+            Issue.record("Metal device unavailable; skipping headless render test")
+            return
+        }
+        let opts = OffscreenRenderOptions(width: 200, height: 200,
+                                          backgroundColor: SIMD4<Float>(0, 0, 0, 1))
+
+        // Box at the origin (identity transform) — fills the centre of the frame.
+        let centered = ViewportBody.box(id: "b", width: 1.5, height: 1.5, depth: 1.5,
+                                        color: SIMD4<Float>(0.9, 0.9, 0.9, 1))
+        guard let imgCentered = renderer.render(bodies: [centered], options: opts) else {
+            Issue.record("nil image"); return
+        }
+
+        // Same box translated far out of the view frustum. If `transform` is
+        // applied it disappears; if ignored (the old behaviour) it would render
+        // identically to the centered case.
+        var moved = ViewportBody.box(id: "b2", width: 1.5, height: 1.5, depth: 1.5,
+                                     color: SIMD4<Float>(0.9, 0.9, 0.9, 1))
+        var t = matrix_identity_float4x4
+        t.columns.3 = SIMD4<Float>(1000, 0, 0, 1)
+        moved.transform = t
+        guard let imgMoved = renderer.render(bodies: [moved], options: opts) else {
+            Issue.record("nil image"); return
+        }
+
+        let nCentered = countNonBackground(imgCentered)
+        let nMoved = countNonBackground(imgMoved)
+        #expect(nCentered > 1000, "centered box should cover the frame, got \(nCentered)")
+        #expect(nMoved < nCentered / 10,
+                "translated-out-of-frame box should mostly disappear; centered=\(nCentered) moved=\(nMoved)")
+    }
+
+    @Test("A modest transform shifts the body toward the offset direction")
+    func transformShiftsCentroid() throws {
+        guard let renderer = OffscreenRenderer() else {
+            Issue.record("Metal device unavailable; skipping headless render test")
+            return
+        }
+        // Camera at +Z looking down -Z, so +X world maps to +X (right) on screen.
+        let camera = CameraState(rotation: simd_quatf(angle: 0, axis: SIMD3<Float>(0, 0, 1)),
+                                 distance: 10, pivot: .zero)
+        let opts = OffscreenRenderOptions(width: 200, height: 200, cameraState: camera,
+                                          backgroundColor: SIMD4<Float>(0, 0, 0, 1))
+
+        var right = ViewportBody.box(id: "r", width: 1, height: 1, depth: 1,
+                                     color: SIMD4<Float>(0.9, 0.9, 0.9, 1))
+        var t = matrix_identity_float4x4
+        t.columns.3 = SIMD4<Float>(2.5, 0, 0, 1)   // shift right
+        right.transform = t
+
+        guard let img = renderer.render(bodies: [right], options: opts) else {
+            Issue.record("nil image"); return
+        }
+        let cx = centroidX(img)
+        // The box was shifted +X, so its rendered centroid should sit right of centre.
+        #expect(cx > Float(img.width) * 0.5, "expected centroid right of centre, got \(cx)")
+    }
+
+    // MARK: - Helpers
+
+    private func countNonBackground(_ image: CGImage, threshold: Int = 24) -> Int {
+        let (buffer, width, height) = readBGRA(image)
+        let bpr = width * 4
+        var count = 0
+        for y in 0..<height {
+            for x in 0..<width {
+                let i = y * bpr + x * 4
+                if Int(buffer[i]) > threshold || Int(buffer[i + 1]) > threshold || Int(buffer[i + 2]) > threshold {
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+
+    /// Mean x of non-background pixels (0 if none).
+    private func centroidX(_ image: CGImage, threshold: Int = 24) -> Float {
+        let (buffer, width, height) = readBGRA(image)
+        let bpr = width * 4
+        var sum = 0, n = 0
+        for y in 0..<height {
+            for x in 0..<width {
+                let i = y * bpr + x * 4
+                if Int(buffer[i]) > threshold || Int(buffer[i + 1]) > threshold || Int(buffer[i + 2]) > threshold {
+                    sum += x; n += 1
+                }
+            }
+        }
+        return n > 0 ? Float(sum) / Float(n) : 0
+    }
+
+    private func readBGRA(_ image: CGImage) -> ([UInt8], Int, Int) {
+        let width = image.width, height = image.height
+        let bpr = width * 4
+        var buffer = [UInt8](repeating: 0, count: bpr * height)
+        let cs = CGColorSpaceCreateDeviceRGB()
+        let info = CGBitmapInfo(rawValue:
+            CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue)
+        buffer.withUnsafeMutableBytes { raw in
+            if let ctx = CGContext(data: raw.baseAddress, width: width, height: height,
+                                   bitsPerComponent: 8, bytesPerRow: bpr, space: cs, bitmapInfo: info.rawValue) {
+                ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            }
+        }
+        return (buffer, width, height)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.10] — 2026-06-06
+
+### Fixed
+- **`OffscreenRenderer` now honours per-body `transform`** (issue #55). Headless renders previously drew every body at its local origin because the offscreen uniforms hard-coded `modelMatrix = identity` — so transformed / instanced / assembled bodies came out piled up. The shaded, transparent, point, and shadow passes now set `modelMatrix = body.transform`, and the shadow-frustum bounds use each body's *transformed* AABB so shadows follow the moved geometry. Matches `ViewportRenderer`. Identity-transform bodies are unchanged.
+- New `OffscreenTransformTests` (2): a body translated out of frame disappears; a `+X` offset shifts its rendered centroid right (126 tests total).
+
 ## [1.1.9] — 2026-06-06
 
 ### Added


### PR DESCRIPTION
Closes #55.

`OffscreenRenderer` hard-coded `modelMatrix = identity`, so transformed / instanced / assembled bodies rendered at their local origins (piled up) in headless output — unlike the live `ViewportRenderer` which applies `body.transform`.

## Fix
- Set `modelMatrix = body.transform` per body in the **shaded**, **transparent** (#53), and **point** passes.
- Set `ShadowUniformsSwift.modelMatrix = body.transform` in the **shadow** pass, and compute the shadow frustum from each body’s **transformed** AABB (`boundingBox.transformed(by:)`) so shadows follow the moved geometry.
- Identity-transform bodies are unchanged (no regression).

## Tests (all acceptance criteria)
- `OffscreenTransformTests`: a body translated far out of frame disappears (would render identically if `transform` were ignored); a `+X` offset shifts the rendered centroid right of centre. **126/126 green.**

This also means headless tests (and the #53 transparency test) can use real transforms instead of baking positions into geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)