### PR TITLE
fix(renderer): scene-adaptive near/far clip planes (closes #57)

### DIFF
--- a/Sources/OCCTSwiftViewport/Camera/CameraState+ClipPlanes.swift
+++ b/Sources/OCCTSwiftViewport/Camera/CameraState+ClipPlanes.swift
@@ -1,0 +1,36 @@
+// CameraState+ClipPlanes.swift
+// ViewportKit
+//
+// Scene-adaptive near/far clip planes (issue #57). A fixed near=0.01 / far=10000
+// range (ratio 1e6) collapses hyperbolic depth precision onto distant geometry,
+// causing z-fighting. Deriving the range from the camera distance and scene
+// radius keeps far/near ~1e3 at any model scale, preserving depth precision.
+
+import simd
+
+extension CameraState {
+
+    /// Returns near/far clip planes fitted to the scene the camera is viewing.
+    ///
+    /// - Parameter sceneBounds: World-space AABB of the visible geometry, or `nil`
+    ///   when unknown (e.g. an empty scene or before the first frame's buffers
+    ///   exist), in which case a wide default is returned.
+    /// - Returns: A `(near, far)` pair with a bounded ratio, so perspective depth
+    ///   precision stays usable regardless of model scale.
+    public func clipPlanes(sceneBounds: BoundingBox?) -> (near: Float, far: Float) {
+        guard let bounds = sceneBounds else { return (0.01, 10_000) }
+
+        let center = bounds.center
+        let radius = max(bounds.diagonalLength * 0.5, 1e-4)
+        let camDist = simd_length(position - center)
+
+        // Far reaches past the back of the scene with margin; near hugs the front
+        // of the scene but is clamped so far/near never exceeds ~1e4.
+        var far = (camDist + radius) * 2.0
+        far = max(far, radius * 2.0)
+        var near = max(camDist - radius, far * 1e-4)
+        near = max(near, 1e-4)
+        if near >= far { near = far * 1e-4 }
+        return (near, far)
+    }
+}

--- a/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
@@ -361,8 +361,17 @@ public final class OffscreenRenderer: Sendable {
         let cameraState = options.cameraState
         let aspectRatio = Float(w) / Float(h)
         let viewMatrix = cameraState.viewMatrix
-        let nearClip: Float = 0.01
-        let farClip: Float = 10000.0
+
+        // Scene-adaptive clip planes (issue #57): fit near/far to the visible
+        // geometry so depth precision isn't crushed by a fixed 0.01/10000 range.
+        var sceneBounds: BoundingBox? = nil
+        for body in bodies where body.isVisible && body.renderLayer == .geometry {
+            guard let box = body.boundingBox?.transformed(by: body.transform) else { continue }
+            sceneBounds = sceneBounds.map { $0.union(box) } ?? box
+        }
+        let clip = cameraState.clipPlanes(sceneBounds: sceneBounds)
+        let nearClip: Float = clip.near
+        let farClip: Float = clip.far
 
         let baseProjMatrix: simd_float4x4
         if let bounds = options.explicitOrthoBounds {

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -1148,7 +1148,20 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
         let aspectRatio = Float(drawableSize.width / drawableSize.height)
 
         let viewMatrix = cameraState.viewMatrix
-        var projMatrix = cameraState.projectionMatrix(aspectRatio: aspectRatio, near: 0.01, far: 10000.0)
+
+        // Scene-adaptive clip planes (issue #57): fit near/far to the visible
+        // geometry so hyperbolic depth precision isn't crushed by a fixed
+        // 0.01/10000 range. Uses the cached per-body AABBs (from the previous
+        // frame on the first frame — bounds change slowly, so that's fine).
+        var sceneBounds: BoundingBox? = nil
+        for body in bodiesBinding.wrappedValue where body.isVisible && body.renderLayer == .geometry {
+            guard let localBox = bodyBufferCache[body.id]?.localBoundingBox else { continue }
+            let worldBox = localBox.transformed(by: body.transform)
+            sceneBounds = sceneBounds.map { $0.union(worldBox) } ?? worldBox
+        }
+        let clip = cameraState.clipPlanes(sceneBounds: sceneBounds)
+
+        var projMatrix = cameraState.projectionMatrix(aspectRatio: aspectRatio, near: clip.near, far: clip.far)
 
         // TAA / progressive accumulation: apply Halton(2,3) sub-pixel jitter to the
         // projection matrix so each frame rasterizes at a different sub-pixel offset.
@@ -1176,8 +1189,8 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
 
         let lighting = controller.lightingConfiguration
 
-        let nearPlane: Float = 0.01
-        let farPlane: Float = 10000.0
+        let nearPlane: Float = clip.near
+        let farPlane: Float = clip.far
 
         // Pack lights from lighting configuration
         let lightSources = [lighting.keyLight, lighting.fillLight, lighting.backLight]

--- a/Tests/OCCTSwiftViewportTests/ClipPlaneTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ClipPlaneTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@Suite("Scene-adaptive clip planes")
+struct ClipPlaneTests {
+
+    /// Camera at +Z looking at the origin from `distance` (identity rotation,
+    /// pivot at origin → camera distance to a centered scene == `distance`).
+    private func camera(distance: Float) -> CameraState {
+        CameraState(rotation: simd_quatf(angle: 0, axis: SIMD3<Float>(0, 0, 1)),
+                    distance: distance, pivot: .zero)
+    }
+
+    @Test("Nil bounds falls back to the wide default")
+    func nilBoundsFallback() {
+        let (near, far) = camera(distance: 10).clipPlanes(sceneBounds: nil)
+        #expect(near == 0.01)
+        #expect(far == 10_000)
+    }
+
+    @Test("Small unit model gets a tight, well-conditioned range")
+    func smallModelTightRange() {
+        let bounds = BoundingBox(min: SIMD3<Float>(-1, -1, -1), max: SIMD3<Float>(1, 1, 1))
+        let (near, far) = camera(distance: 6).clipPlanes(sceneBounds: bounds)
+        #expect(near > 0)
+        #expect(near < far)
+        #expect(near > 3 && near < 6)        // hugs the front of the model
+        #expect(far / near < 100)            // vs ~1e6 with the old fixed range
+    }
+
+    @Test("Large mm-scale model (railcar-ish) keeps the ratio bounded — fixes #57")
+    func largeModelBoundedRatio() {
+        // ~37.9 × 50.1 × 269.5 mm, like the reported railcar STL.
+        let bounds = BoundingBox(min: SIMD3<Float>(-19, -25, -135),
+                                 max: SIMD3<Float>(19, 25, 135))
+        let (near, far) = camera(distance: 400).clipPlanes(sceneBounds: bounds)
+        #expect(near > 0 && near < far)
+        #expect(far / near < 100,
+                "ratio must stay sane at mm scale; got near=\(near) far=\(far) ratio=\(far / near)")
+    }
+
+    @Test("Camera inside the scene still yields a valid positive range")
+    func cameraInsideScene() {
+        let bounds = BoundingBox(min: SIMD3<Float>(-5, -5, -5), max: SIMD3<Float>(5, 5, 5))
+        let (near, far) = camera(distance: 0.5).clipPlanes(sceneBounds: bounds)
+        #expect(near > 0)
+        #expect(near < far)
+    }
+
+    @Test("Range scales with the model — tiny and huge models both stay conditioned")
+    func scalesWithModel() {
+        let tiny = BoundingBox(min: SIMD3<Float>(repeating: -0.001), max: SIMD3<Float>(repeating: 0.001))
+        let huge = BoundingBox(min: SIMD3<Float>(repeating: -5000), max: SIMD3<Float>(repeating: 5000))
+        let (tn, tf) = camera(distance: 0.01).clipPlanes(sceneBounds: tiny)
+        let (hn, hf) = camera(distance: 20_000).clipPlanes(sceneBounds: huge)
+        #expect(tn > 0 && tn < tf && tf / tn < 1000)
+        #expect(hn > 0 && hn < hf && hf / hn < 1000)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.11] — 2026-06-06
+
+### Fixed
+- **Z-fighting from a fixed near/far clip range** (issue #57). The renderers hard-coded `near = 0.01` / `far = 10000` (ratio 1e6), which collapses hyperbolic depth precision onto distant geometry — adjacent triangles on large / real-scale models (e.g. an mm-scale STL hundreds of units out) round to the same depth and flicker. Clip planes are now **scene-adaptive**: derived each frame from the camera distance and the visible scene's bounding radius (`CameraState.clipPlanes(sceneBounds:)`), keeping `far/near` ~1e3 at any model scale. Applied in both `ViewportRenderer` (cached per-body AABBs) and `OffscreenRenderer`. Empty scenes fall back to the old wide default. No consumer tuning required; no API change.
+- New `ClipPlaneTests` (5) covering unit / mm-scale / camera-inside / tiny / huge cases (131 tests total). Live rendering verified unchanged on the Vision Pro simulator.
+
+### Note
+- Reversed-Z (the issue's "best for CAD" option) would push precision even further but requires flipping every depth state / clear / compare; scene-adaptive planes resolve the reported flicker with far less risk and are the change shipped here. The measurement-overlay projection in `MetalViewportView` keeps the wide range deliberately — near/far don't affect screen-space x/y, only depth.
+
 ## [1.1.10] — 2026-06-06
 
 ### Fixed


### PR DESCRIPTION
Closes #57.

The renderers hard-coded `near = 0.01` / `far = 10000` (ratio **1e6**). Perspective depth precision is hyperbolic — concentrated just past the near plane — so on large / real-scale models (the reported mm-scale railcar STL viewed a few hundred units out) the whole model lands in the last tiny depth band and adjacent triangles round to equal depth → flicker.

## Fix (option 1: scene-adaptive)
- **`CameraState.clipPlanes(sceneBounds:)`** derives `near`/`far` each frame from the camera-to-scene distance and the scene radius, keeping `far/near` ~1e3 at any model scale. Empty scenes fall back to the old wide default.
- `ViewportRenderer` computes scene bounds from the **cached** per-body AABBs (no per-frame vertex rescans); `OffscreenRenderer` from the bodies’ transformed AABBs. Both feed the projection and the depth uniforms.
- No API change, no consumer tuning.

## Acceptance
- mm-scale model: `near=261 far=1077` (ratio ~4) instead of 1e6 → flicker resolved. ✅
- Tiny (sub-unit) and huge (thousands of units) models both stay well-conditioned without tuning (`ClipPlaneTests`). ✅
- Works in `ViewportRenderer` (live) and `OffscreenRenderer` (headless). ✅

## Tests / verification
- `ClipPlaneTests` (5): nil-fallback, unit, mm-scale (ratio < 100), camera-inside, tiny/huge scaling. **131/131 green.**
- Live rendering verified unchanged on the Vision Pro simulator (primitives/wireframe/arc clean; helpers fine).

## Notes
- **Reversed-Z** (the issue’s “best for CAD” option) would extend precision further but requires flipping every depth state / clear / compare across both renderers + shadow + pick — high risk. Scene-adaptive planes resolve the reported flicker with far less surface; reversed-Z can be a follow-up.
- The measurement-overlay projection in `MetalViewportView` keeps the wide range on purpose: near/far affect only depth, not screen-space x/y, so overlay label positions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)