### PR TITLE
feat(viewcube): interactive 3D navigation cube (closes #60)

### DIFF
--- a/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+++ b/Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
@@ -140,6 +140,8 @@ public typealias _DynamicPivotConfiguration = DynamicPivotConfiguration
 // ViewCube
 public typealias _ViewCubeView = ViewCubeView
 public typealias _ViewCubeRegion = ViewCubeRegion
+public typealias _NavigationCubeView = NavigationCubeView
+public typealias _NavigationCube = NavigationCube
 
 // HUD overlays
 public typealias _OrientationGnomon = OrientationGnomon

--- a/Sources/OCCTSwiftViewport/ViewCube/NavigationCube.swift
+++ b/Sources/OCCTSwiftViewport/ViewCube/NavigationCube.swift
@@ -1,0 +1,170 @@
+// NavigationCube.swift
+// ViewportKit
+//
+// Pure projection + hit-testing for the interactive navigation cube (issue #60).
+// SwiftUI-free so it can be unit-tested without a view.
+
+import simd
+import CoreGraphics
+
+/// Projects a unit cube under a camera rotation and resolves taps to one of the
+/// 26 `ViewCubeRegion`s (6 faces / 12 edges / 8 corners).
+///
+/// Convention matches the existing ViewCube: a world point projects to screen as
+/// `(rotatedₓ, -rotated_y)` where `rotated = rotation.inverse.act(point)`, and the
+/// face↔axis mapping is +X=right, -X=left, +Y=back, -Y=front, +Z=top, -Z=bottom.
+public struct NavigationCube {
+
+    /// Current camera rotation the cube tracks.
+    public var rotation: simd_quatf
+    /// Widget side length in points.
+    public var size: CGFloat
+    /// Inset from the widget edge, in points.
+    public var padding: CGFloat
+
+    public init(rotation: simd_quatf, size: CGFloat, padding: CGFloat = 6) {
+        self.rotation = rotation
+        self.size = size
+        self.padding = padding
+    }
+
+    /// Pixels per cube unit. The rotated cube's silhouette reaches ~√3 units; we
+    /// scale so a face (±1) fits comfortably with the corners allowed to approach
+    /// the edges.
+    public var scale: CGFloat { (size * 0.5 - padding) / 1.45 }
+
+    private var center: CGPoint { CGPoint(x: size * 0.5, y: size * 0.5) }
+
+    /// Projects a cube-local point (`[-1,1]³`) to widget coordinates.
+    public func project(_ p: SIMD3<Float>) -> CGPoint {
+        let r = rotation.inverse.act(p)
+        return CGPoint(x: center.x + CGFloat(r.x) * scale,
+                       y: center.y - CGFloat(r.y) * scale)
+    }
+
+    // MARK: - Faces
+
+    /// The 6 faces with their outward normals (cube convention above).
+    static let faces: [(region: ViewCubeRegion, normal: SIMD3<Float>)] = [
+        (.right,  SIMD3( 1, 0, 0)),
+        (.left,   SIMD3(-1, 0, 0)),
+        (.back,   SIMD3( 0, 1, 0)),
+        (.front,  SIMD3( 0,-1, 0)),
+        (.top,    SIMD3( 0, 0, 1)),
+        (.bottom, SIMD3( 0, 0,-1)),
+    ]
+
+    /// A face that currently faces the camera, with its projected geometry.
+    public struct VisibleFace {
+        public let region: ViewCubeRegion
+        public let corners: [CGPoint]   // 4, in projected order
+        public let center: CGPoint
+        public let depth: Float         // toward-camera depth of the face centre (for sorting)
+    }
+
+    /// The faces pointing toward the camera, back-to-front (draw in order).
+    public func visibleFaces() -> [VisibleFace] {
+        let viewDir = rotation.act(SIMD3<Float>(0, 0, -1))   // where the camera looks
+        var result: [VisibleFace] = []
+        for face in Self.faces {
+            // Visible when the outward normal opposes the look direction.
+            if simd_dot(face.normal, viewDir) >= -1e-4 { continue }
+            let corners3 = Self.faceCorners(normal: face.normal)
+            let projected = corners3.map { project($0) }
+            // Depth = component of the face centre along the toward-camera axis.
+            let towardCam = rotation.act(SIMD3<Float>(0, 0, 1))
+            let depth = simd_dot(face.normal, towardCam)
+            result.append(VisibleFace(region: face.region,
+                                      corners: projected,
+                                      center: project(face.normal),
+                                      depth: depth))
+        }
+        return result.sorted { $0.depth < $1.depth }   // far first
+    }
+
+    /// The four corners of a face (cube-local), ordered around the face.
+    static func faceCorners(normal n: SIMD3<Float>) -> [SIMD3<Float>] {
+        // Two in-plane axes.
+        let u: SIMD3<Float>
+        let v: SIMD3<Float>
+        if abs(n.x) > 0.5 { u = SIMD3(0, 1, 0); v = SIMD3(0, 0, 1) }
+        else if abs(n.y) > 0.5 { u = SIMD3(1, 0, 0); v = SIMD3(0, 0, 1) }
+        else { u = SIMD3(1, 0, 0); v = SIMD3(0, 1, 0) }
+        return [n - u - v, n + u - v, n + u + v, n - u + v]
+    }
+
+    // MARK: - Hit testing
+
+    /// Resolves a tap (widget coordinates) to a region, or `nil` if it misses the
+    /// cube silhouette. Casts the tap as a ray through the cube and classifies the
+    /// frontmost surface point into the 3×3-per-face grid.
+    public func region(at point: CGPoint) -> ViewCubeRegion? {
+        guard scale > 0 else { return nil }
+        // Tap in the rotated frame's screen plane (x right, y up).
+        let tx = Float((point.x - center.x) / scale)
+        let ty = Float((center.y - point.y) / scale)   // screen y is down → flip
+
+        // Ray in world space: base + s * dir, where +s goes toward the camera.
+        let base = rotation.act(SIMD3<Float>(tx, ty, 0))
+        let dir = rotation.act(SIMD3<Float>(0, 0, 1))
+
+        guard let (sNear, sFar) = Self.intersectUnitCube(base: base, dir: dir),
+              sFar >= sNear else { return nil }
+        let surface = base + sFar * dir   // frontmost (toward camera)
+
+        return Self.classify(surface)
+    }
+
+    /// Slab clip of `base + s·dir` against `[-1,1]³`. Returns the `s` interval, or nil.
+    static func intersectUnitCube(base: SIMD3<Float>, dir: SIMD3<Float>) -> (Float, Float)? {
+        var tMin = -Float.greatestFiniteMagnitude
+        var tMax = Float.greatestFiniteMagnitude
+        for axis in 0..<3 {
+            let b = base[axis], d = dir[axis]
+            if abs(d) < 1e-6 {
+                if b < -1 || b > 1 { return nil }   // parallel & outside this slab
+            } else {
+                var t0 = (-1 - b) / d
+                var t1 = (1 - b) / d
+                if t0 > t1 { swap(&t0, &t1) }
+                tMin = max(tMin, t0)
+                tMax = min(tMax, t1)
+                if tMin > tMax { return nil }
+            }
+        }
+        return (tMin, tMax)
+    }
+
+    /// Classifies a cube-surface point into a region. Each tangent coordinate in
+    /// the outer third (|c| > 1/3) activates that face; the hit face's own
+    /// near-±1 coordinate is always active. 1–3 active faces → face/edge/corner.
+    static func classify(_ p: SIMD3<Float>) -> ViewCubeRegion? {
+        let t: Float = 1.0 / 3.0
+        var active: Set<ViewCubeRegion> = []
+        if p.z > t { active.insert(.top) } else if p.z < -t { active.insert(.bottom) }
+        if p.y > t { active.insert(.back) } else if p.y < -t { active.insert(.front) }
+        if p.x > t { active.insert(.right) } else if p.x < -t { active.insert(.left) }
+        guard !active.isEmpty else { return nil }
+        return regionLookup[active]
+    }
+
+    /// `Set<face regions>` → the combined region (built from each region's faces).
+    static let regionLookup: [Set<ViewCubeRegion>: ViewCubeRegion] = {
+        var map: [Set<ViewCubeRegion>: ViewCubeRegion] = [:]
+        for region in ViewCubeRegion.allCases {
+            map[region.baseFaceSet] = region
+        }
+        return map
+    }()
+}
+
+extension ViewCubeRegion {
+    /// The 1–3 base faces this region combines, e.g. `.topFrontRight → {top,front,right}`.
+    var baseFaceSet: Set<ViewCubeRegion> {
+        let names: [String: ViewCubeRegion] = [
+            "top": .top, "bottom": .bottom, "front": .front,
+            "back": .back, "left": .left, "right": .right,
+        ]
+        return Set(displayName.lowercased().split(separator: "-").compactMap { names[String($0)] })
+    }
+}

--- a/Sources/OCCTSwiftViewport/ViewCube/NavigationCubeView.swift
+++ b/Sources/OCCTSwiftViewport/ViewCube/NavigationCubeView.swift
@@ -1,0 +1,98 @@
+// NavigationCubeView.swift
+// ViewportKit
+//
+// Interactive 3D navigation cube (issue #60): a corner widget that tracks the
+// camera and snaps to plan/elevation/iso views when its faces, edges, or corners
+// are clicked. Geometry + hit-testing live in `NavigationCube` (unit-tested).
+
+import SwiftUI
+import simd
+
+/// A Shapr3D / Fusion-style navigation cube. Renders the cube under the current
+/// camera rotation and routes taps on faces / edges / corners to the matching
+/// `ViewCubeRegion` via `ViewportController.goToRegion(_:)`.
+public struct NavigationCubeView: View {
+
+    @ObservedObject private var controller: ViewportController
+    @State private var hovered: ViewCubeRegion?
+
+    public init(controller: ViewportController) {
+        self.controller = controller
+    }
+
+    public var body: some View {
+        GeometryReader { geo in
+            let side = min(geo.size.width, geo.size.height)
+            let cube = NavigationCube(rotation: controller.cameraState.rotation, size: side)
+
+            Canvas { ctx, _ in
+                for face in cube.visibleFaces() {
+                    var path = Path()
+                    path.move(to: face.corners[0])
+                    for c in face.corners.dropFirst() { path.addLine(to: c) }
+                    path.closeSubpath()
+
+                    let isHovered = (hovered?.baseFaceSet.contains(face.region) ?? false)
+                    ctx.fill(path, with: .color(faceColor(depth: face.depth, hovered: isHovered)))
+                    ctx.stroke(path, with: .color(.primary.opacity(0.45)), lineWidth: 1)
+
+                    ctx.draw(
+                        Text(label(face.region))
+                            .font(.system(size: max(7, side * 0.12), weight: .semibold)),
+                        at: face.center
+                    )
+                }
+            }
+            .frame(width: side, height: side)
+            .contentShape(Rectangle())
+            #if os(macOS)
+            .onContinuousHover { phase in
+                switch phase {
+                case .active(let p): hovered = cube.region(at: p)
+                case .ended: hovered = nil
+                }
+            }
+            #endif
+            .gesture(
+                SpatialTapGesture()
+                    .onEnded { value in
+                        if let region = cube.region(at: value.location) {
+                            controller.goToRegion(region)
+                        }
+                    }
+            )
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .accessibilityLabel("Navigation cube")
+    }
+
+    private func faceColor(depth: Float, hovered: Bool) -> Color {
+        if hovered { return Color.accentColor.opacity(0.85) }
+        // Brighter for the most camera-facing face.
+        let shade = 0.55 + Double(max(0, min(1, depth))) * 0.35
+        return Color.gray.opacity(shade)
+    }
+
+    private func label(_ region: ViewCubeRegion) -> String {
+        switch region {
+        case .top: return "TOP"
+        case .bottom: return "BOT"
+        case .front: return "FRONT"
+        case .back: return "BACK"
+        case .right: return "RIGHT"
+        case .left: return "LEFT"
+        default: return ""
+        }
+    }
+}
+
+#if DEBUG
+struct NavigationCubeView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationCubeView(controller: ViewportController())
+            .frame(width: 100, height: 100)
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -392,7 +392,7 @@ public struct MetalViewportView: View {
             Spacer()
             HStack {
                 Spacer()
-                ViewCubeView(controller: controller)
+                NavigationCubeView(controller: controller)
                     .frame(width: 80, height: 80)
                     .padding(12)
             }

--- a/Sources/OCCTSwiftViewport/Views/ViewportController.swift
+++ b/Sources/OCCTSwiftViewport/Views/ViewportController.swift
@@ -211,6 +211,14 @@ public final class ViewportController: ObservableObject {
         cameraController.animateTo(state, duration: duration)
     }
 
+    /// Animates to a ViewCube region (face / edge / corner), preserving the current
+    /// pivot, distance and projection — only the orientation changes (issue #60).
+    public func goToRegion(_ region: ViewCubeRegion, duration: Float = 0.3) {
+        var target = cameraState
+        target.rotation = region.cameraState().rotation
+        cameraController.animateTo(target, duration: duration)
+    }
+
     // MARK: - Camera Control
 
     /// Handles orbit gesture input.

--- a/Tests/OCCTSwiftViewportTests/NavigationCubeTests.swift
+++ b/Tests/OCCTSwiftViewportTests/NavigationCubeTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import simd
+import CoreGraphics
+@testable import OCCTSwiftViewport
+
+@Suite("Navigation cube geometry + hit-testing")
+struct NavigationCubeTests {
+
+    // MARK: - Region ↔ base faces
+
+    @Test("Every region maps to the right number of base faces; lookup is complete")
+    func baseFaceSets() {
+        for r in ViewCubeRegion.allCases {
+            let n = r.baseFaceSet.count
+            if r.isFace { #expect(n == 1) }
+            else if r.isEdge { #expect(n == 2) }
+            else if r.isCorner { #expect(n == 3) }
+        }
+        // All 26 regions are reachable via their face set (no collisions).
+        #expect(NavigationCube.regionLookup.count == ViewCubeRegion.allCases.count)
+    }
+
+    // MARK: - classify()
+
+    @Test("Surface points classify into face / edge / corner")
+    func classifyPoints() {
+        #expect(NavigationCube.classify(SIMD3(0, 0, 1)) == .top)
+        #expect(NavigationCube.classify(SIMD3(0, 0, -1)) == .bottom)
+        #expect(NavigationCube.classify(SIMD3(1, 0, 0)) == .right)
+        #expect(NavigationCube.classify(SIMD3(0, -1, 0)) == .front)
+        // Edge: right + back.
+        #expect(NavigationCube.classify(SIMD3(1, 0.5, 0)) == .backRight)
+        // Corner: top + back + right.
+        #expect(NavigationCube.classify(SIMD3(1, 1, 1)) == .topBackRight)
+        // Front-left-top corner.
+        #expect(NavigationCube.classify(SIMD3(-1, -1, 1)) == .topFrontLeft)
+    }
+
+    // MARK: - Cube ray intersection
+
+    @Test("Ray through the centre hits the cube; a far-offset ray misses")
+    func rayIntersection() {
+        let hit = NavigationCube.intersectUnitCube(base: SIMD3(0, 0, 0), dir: SIMD3(0, 0, 1))
+        #expect(hit != nil)
+        let miss = NavigationCube.intersectUnitCube(base: SIMD3(5, 0, 0), dir: SIMD3(0, 0, 1))
+        #expect(miss == nil)
+    }
+
+    // MARK: - End-to-end hit-test (identity rotation → looking at the top face)
+
+    @Test("Identity rotation: taps resolve to the expected face/edge/corner")
+    func identityHitTest() {
+        let cube = NavigationCube(rotation: simd_quatf(angle: 0, axis: SIMD3(0, 0, 1)), size: 80)
+        let s = cube.scale
+        let c = CGPoint(x: 40, y: 40)
+
+        // Centre → the face we're looking at (top, given the convention).
+        #expect(cube.region(at: c) == .top)
+        // Right of centre → top-right edge.
+        #expect(cube.region(at: CGPoint(x: c.x + CGFloat(0.6) * s, y: c.y)) == .topRight)
+        // Up-right (screen y is down, so subtract) → top-back-right corner.
+        #expect(cube.region(at: CGPoint(x: c.x + CGFloat(0.6) * s, y: c.y - CGFloat(0.6) * s)) == .topBackRight)
+        // Down-left → top-front-left corner.
+        #expect(cube.region(at: CGPoint(x: c.x - CGFloat(0.6) * s, y: c.y + CGFloat(0.6) * s)) == .topFrontLeft)
+        // Far outside the silhouette → miss.
+        #expect(cube.region(at: CGPoint(x: c.x + 10 * s, y: c.y)) == nil)
+    }
+
+    // MARK: - Visible faces
+
+    @Test("At most three faces are visible and they front-face the camera")
+    func visibleFaceCount() {
+        // A generic tilt so three faces show.
+        let rot = simd_quatf(angle: 0.6, axis: simd_normalize(SIMD3<Float>(1, 1, 0)))
+        let cube = NavigationCube(rotation: rot, size: 80)
+        let visible = cube.visibleFaces()
+        #expect(visible.count >= 1 && visible.count <= 3)
+        // Identity shows exactly one face (axis-aligned).
+        let axisCube = NavigationCube(rotation: simd_quatf(angle: 0, axis: SIMD3(0, 0, 1)), size: 80)
+        #expect(axisCube.visibleFaces().count == 1)
+        #expect(axisCube.visibleFaces().first?.region == .top)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.12] — 2026-06-08
+
+### Added
+- **Interactive 3D navigation cube** (issue #60) — a Shapr3D / Fusion-style `NavigationCubeView` replacing the orientation-gizmo `ViewCubeView` in the corner overlay. It renders a cube that tracks `cameraState.rotation`, with **clickable faces, edges, and corners** that animate to the matching plan / elevation / isometric view.
+  - New `NavigationCube` — pure, SwiftUI-free projection + hit-testing. Taps are unprojected to a ray, intersected with the unit cube, and the frontmost surface point is classified into the 3×3-per-face grid → one of the 26 `ViewCubeRegion`s (faces / edges / corners). Robust on iOS (touch) and macOS (click + hover highlight).
+  - New `ViewportController.goToRegion(_:duration:)` — animates to a region's orientation, preserving the current pivot / distance / projection.
+  - `NavigationCube` / `NavigationCubeView` re-exported (`_NavigationCube` / `_NavigationCubeView`). `ViewCubeView` is retained (still re-exported) for source compatibility.
+  - New `NavigationCubeTests` (5): region↔base-face mapping + 26-region lookup completeness, surface-point classification, ray-cube intersection, and end-to-end identity-rotation hit-testing (centre→face, edges, corners, miss). 136 tests total; cube rendering verified on the Vision Pro simulator.
+
 ## [1.1.11] — 2026-06-06
 
 ### Fixed


### PR DESCRIPTION
Closes #60.

Replaces the orientation-gizmo `ViewCubeView` in the corner overlay with **`NavigationCubeView`** — a Shapr3D / Fusion-style cube that tracks the camera and snaps to plan / elevation / iso views when its **faces, edges, or corners** are clicked.

## Design
- **`NavigationCube`** — pure (SwiftUI-free) projection + hit-testing, fully unit-tested. A tap is unprojected to a ray, intersected with the unit cube (slab clip), and the **frontmost** surface point is classified into the **3×3-per-face grid** (tangent coord in the outer third → that neighbour face active) → one of the 26 `ViewCubeRegion`s. Correct-by-construction; no fragile per-face enumeration.
- **`ViewportController.goToRegion(_:duration:)`** — animates to the region’s orientation, preserving the current pivot / distance / projection (so it works exactly like `goToStandardView` but for any of the 26 regions; the region rotations already existed in `ViewCubeRegion`).
- SwiftUI `NavigationCubeView`: renders visible faces (depth-shaded) with labels, `SpatialTapGesture` for taps (iOS touch + macOS click), and a macOS hover highlight.
- `ViewCubeView` retained + still re-exported (source-compatible); the overlay now uses the new cube.

## Acceptance
- Cube tracks `controller.cameraState.rotation`. ✅
- Tapping a face/edge/corner animates to the matching view via `goToRegion`. ✅
- Robust hit-testing on iOS + macOS (`SpatialTapGesture` + the unit-tested ray classifier). ✅

## Tests / verification
- `NavigationCubeTests` (5): region↔base-face mapping + **26-region lookup completeness**, surface classification (face/edge/corner), ray–cube intersection, and **end-to-end identity-rotation hit-testing** (centre→top, edge, corner, miss). **136/136 green.**
- Cube rendering verified on the Vision Pro simulator. Interactive click-to-snap can’t be scripted in the sim — best confirmed by a tap on device — but the hit classifier it routes through is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)