### PR TITLE
fix(viewcube): honour viewCubePosition in the overlay (closes #62)

### DIFF
--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -6,6 +6,18 @@
 import SwiftUI
 import simd
 
+extension ViewCubePosition {
+    /// SwiftUI alignment for placing the view-cube overlay in its corner (issue #62).
+    var overlayAlignment: Alignment {
+        switch self {
+        case .topLeading: return .topLeading
+        case .topTrailing: return .topTrailing
+        case .bottomLeading: return .bottomLeading
+        case .bottomTrailing: return .bottomTrailing
+        }
+    }
+}
+
 /// A 3D viewport view using Metal.
 ///
 /// MetalViewportView provides a complete Metal-based 3D viewing experience with:
@@ -388,15 +400,13 @@ public struct MetalViewportView: View {
     // MARK: - ViewCube Overlay
 
     private var viewCubeOverlay: some View {
-        VStack {
-            Spacer()
-            HStack {
-                Spacer()
-                NavigationCubeView(controller: controller)
-                    .frame(width: 80, height: 80)
-                    .padding(12)
-            }
-        }
+        // Honour configuration.viewCubePosition (issue #62) and keep clear of the
+        // safe area (e.g. an iPhone bottom sheet covering bottom-trailing).
+        NavigationCubeView(controller: controller)
+            .frame(width: 80, height: 80)
+            .padding(12)
+            .frame(maxWidth: .infinity, maxHeight: .infinity,
+                   alignment: controller.configuration.viewCubePosition.overlayAlignment)
     }
 
     // MARK: - HUD Overlays

--- a/Tests/OCCTSwiftViewportTests/ViewCubePositionTests.swift
+++ b/Tests/OCCTSwiftViewportTests/ViewCubePositionTests.swift
@@ -1,0 +1,21 @@
+import Testing
+import SwiftUI
+@testable import OCCTSwiftViewport
+
+@Suite("ViewCube position")
+struct ViewCubePositionTests {
+
+    @Test("Each position maps to the matching SwiftUI alignment (#62)")
+    func positionToAlignment() {
+        #expect(ViewCubePosition.topLeading.overlayAlignment == .topLeading)
+        #expect(ViewCubePosition.topTrailing.overlayAlignment == .topTrailing)
+        #expect(ViewCubePosition.bottomLeading.overlayAlignment == .bottomLeading)
+        #expect(ViewCubePosition.bottomTrailing.overlayAlignment == .bottomTrailing)
+    }
+
+    @Test("Default configuration keeps the cube bottom-trailing (no behaviour change)")
+    func defaultPositionUnchanged() {
+        #expect(ViewportConfiguration().viewCubePosition == .bottomTrailing)
+        #expect(ViewportConfiguration.cad.viewCubePosition == .bottomTrailing)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.13] — 2026-06-08
+
+### Fixed
+- **View-cube overlay now honours `ViewportConfiguration.viewCubePosition`** (issue #62). The overlay was hardcoded to bottom-trailing, so the cube couldn't be moved — a real problem on iPhone where a bottom sheet covers that corner. It now maps the `.topLeading` / `.topTrailing` / `.bottomLeading` / `.bottomTrailing` config to the overlay alignment (within the safe area), so a host can move the cube clear of other UI. Default stays bottom-trailing (no behaviour change).
+- New `ViewCubePositionTests` (2). 138 tests total.
+
 ## [1.1.12] — 2026-06-08
 
 ### Added


### PR DESCRIPTION
Closes #62.

The view-cube overlay in `MetalViewportView` was hardcoded bottom-trailing, so `ViewportConfiguration.viewCubePosition` had no effect — and on iPhone a bottom sheet covers that corner, hiding the cube. The overlay now positions the cube via `viewCubePosition.overlayAlignment` (`.topLeading/.topTrailing/.bottomLeading/.bottomTrailing`), within the safe area, so a host can move it clear of other UI (e.g. `.topTrailing` on iPhone).

Default is unchanged (bottom-trailing). Also lands cleanly on the new `NavigationCubeView` from #60.

## Tests
`ViewCubePositionTests` (2): enum→alignment mapping + default-position preserved. **138/138 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)