### PR TITLE
feat(picking): ViewportBody.isPickable to exclude bodies from picks (closes #63)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -1881,6 +1881,9 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                     for body in bodies where body.isVisible {
                         let bodyObjectIndex = objectIndex
                         objectIndex += 1
+                        // Non-pickable bodies (issue #63) are skipped, but objectIndex
+                        // still advances so the remaining bodies keep their pick IDs.
+                        if !body.isPickable { continue }
                         guard let buffers = bodyBufferCache[body.id] else {
                             continue
                         }
@@ -1955,6 +1958,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                             for body in bodies where body.isVisible {
                                 let bodyObjectIndex = objectIndex
                                 objectIndex += 1
+                                if !body.isPickable { continue }   // issue #63
                                 guard !body.edgeIndices.isEmpty,
                                       let buffers = bodyBufferCache[body.id],
                                       let edgeVB = buffers.edgeVertexBuffer,
@@ -1985,6 +1989,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                         pickEncoder.setRenderPipelineState(pickArcPipeline)
                         pickEncoder.setVertexBuffer(arcBuf, offset: 0, index: 0)
                         for d in frameArcDraws {
+                            if !d.body.isPickable { continue }   // issue #63
                             var uniforms = makeUniforms()
                             uniforms.modelMatrix = d.body.transform
                             var bodyUniforms = BodyUniforms(body: d.body, objectIndex: d.objectIndex)
@@ -2010,6 +2015,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                             for body in bodies where body.isVisible {
                                 let bodyObjectIndex = objectIndex
                                 objectIndex += 1
+                                if !body.isPickable { continue }   // issue #63
                                 guard !body.vertices.isEmpty,
                                       let buffers = bodyBufferCache[body.id],
                                       let pointVB = buffers.pointVertexBuffer,
@@ -2040,6 +2046,7 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                         for body in bodies where body.isVisible {
                             let bodyObjectIndex = objectIndex
                             objectIndex += 1
+                            if !body.isPickable { continue }   // issue #63
                             guard body.renderLayer == .overlay,
                                   let buffers = bodyBufferCache[body.id],
                                   let vb = buffers.vertexBuffer,

--- a/Sources/OCCTSwiftViewport/Types/ViewportBody.swift
+++ b/Sources/OCCTSwiftViewport/Types/ViewportBody.swift
@@ -160,6 +160,12 @@ public struct ViewportBody: Identifiable, Sendable {
     /// Whether this body should be rendered.
     public var isVisible: Bool
 
+    /// Whether this body participates in GPU picking (issue #63). When `false` the
+    /// body is still drawn but excluded from the pick buffer, so it never wins a
+    /// pick over the geometry behind it — useful for always-on-top reference bodies
+    /// (datum/ground planes, overlays) that shouldn't steal face/edge/vertex picks.
+    public var isPickable: Bool
+
     /// Render-time layer. `.overlay` bodies are drawn always-on-top.
     public var renderLayer: RenderLayer
 
@@ -191,6 +197,7 @@ public struct ViewportBody: Identifiable, Sendable {
         pointRadius: Float = 0.05,
         primitiveKind: BodyPrimitiveKind = .mesh,
         isVisible: Bool = true,
+        isPickable: Bool = true,
         renderLayer: RenderLayer = .geometry,
         pickLayer: PickLayer = .userGeometry,
         transform: simd_float4x4 = matrix_identity_float4x4
@@ -215,6 +222,7 @@ public struct ViewportBody: Identifiable, Sendable {
         self.pointRadius = pointRadius
         self.primitiveKind = primitiveKind
         self.isVisible = isVisible
+        self.isPickable = isPickable
         self.renderLayer = renderLayer
         self.pickLayer = pickLayer
         self.transform = transform

--- a/Tests/OCCTSwiftViewportTests/PickabilityTests.swift
+++ b/Tests/OCCTSwiftViewportTests/PickabilityTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+@Suite("ViewportBody pickability")
+struct PickabilityTests {
+
+    @Test("isPickable defaults to true and is source-compatible (#63)")
+    func defaultsPickable() {
+        let body = ViewportBody(id: "a", vertexData: [], indices: [], edges: [], color: .one)
+        #expect(body.isPickable)
+    }
+
+    @Test("A body can be marked non-pickable while staying visible")
+    func nonPickableStaysVisible() {
+        let body = ViewportBody(id: "datum", vertexData: [], indices: [], edges: [],
+                                color: .one, isVisible: true, isPickable: false)
+        #expect(body.isVisible)      // still drawn
+        #expect(!body.isPickable)    // excluded from the pick buffer
+    }
+
+    @Test("Primitive factory bodies are pickable by default")
+    func primitivesPickable() {
+        #expect(ViewportBody.box(id: "box").isPickable)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.14] — 2026-06-08
+
+### Added
+- **`ViewportBody.isPickable`** (issue #63, default `true`). A body can now be drawn but excluded from the GPU pick buffer, so always-on-top reference geometry (datum / ground planes, overlays) no longer steals face/edge/vertex picks from the geometry behind it. Gated alongside `isVisible` in every pick sub-pass — geometry, edge, arc, vertex, and the overlay pick pass — with the object index still advancing so remaining bodies keep stable pick IDs. Unlike `selectionFilter` (which rejects a pick *after* the GPU returns it), this stops the body from occluding the pick buffer at all, so the geometry behind it is actually sampled.
+- New `PickabilityTests` (3). 141 tests total. Default `true` → no behaviour change for existing bodies.
+
 ## [1.1.13] — 2026-06-08
 
 ### Fixed


### PR DESCRIPTION
Closes #63.

Overlay / reference bodies (e.g. a datum or ground plane drawn always-on-top) were winning every face pick: the pick pass draws overlay bodies with always-pass depth, the only gate was `isVisible`, and `selectionFilter` only rejects the decoded `PickResult` *after* the GPU already returned the plane (so the geometry behind it was never sampled).

## Fix
- **`ViewportBody.isPickable: Bool = true`** — draw the body but exclude it from the pick buffer.
- Gated alongside `isVisible` in **every** pick sub-pass: geometry, edge, arc (#48), vertex, and the overlay pick pass. The object index still advances for skipped bodies, so the remaining bodies keep stable pick IDs (same pattern as frustum culling).
- Because the body is never rasterised into the pick texture, the geometry behind it **is** sampled — the real fix vs. post-filtering.

## Notes
- Default `true` → **no behaviour change** for existing bodies (the gate is a no-op unless a host opts a body out).
- Complements `selectionFilter` (kind/layer/predicate filtering): `isPickable` removes a body from picking entirely; `selectionFilter` constrains which returned picks are accepted.

## Tests
`PickabilityTests` (3): default-true, non-pickable-but-visible, primitives pickable. **141/141 green.** (The GPU pick-buffer exclusion needs a live draw + readback to observe, so it isn’t headlessly asserted; the gating mirrors the proven frustum-cull skip and is consistent across all pick passes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)