### PR TITLE
fix(viewcube): reverse cube drag-orbit direction (follow-up to #60)

### DIFF
--- a/Sources/OCCTSwiftViewport/ViewCube/NavigationCubeView.swift
+++ b/Sources/OCCTSwiftViewport/ViewCube/NavigationCubeView.swift
@@ -78,14 +78,17 @@ public struct NavigationCubeView: View {
                             let dy = value.translation.height - lastDrag.height
                             lastDrag = value.translation
                             // Grab-and-spin: always orbit (independent of the
-                            // viewport's gesture-action mapping).
-                            controller.handleOrbit(translation: CGSize(width: -dx, height: dy))
+                            // viewport's gesture-action mapping). The cube is a
+                            // camera proxy, so dragging it orbits the camera *around*
+                            // the model — the opposite sign to the viewport's
+                            // grab-the-model drag.
+                            controller.handleOrbit(translation: CGSize(width: dx, height: -dy))
                         }
                     }
                     .onEnded { value in
                         if isOrbiting {
-                            controller.endOrbit(velocity: CGSize(width: -value.velocity.width,
-                                                                 height: value.velocity.height))
+                            controller.endOrbit(velocity: CGSize(width: value.velocity.width,
+                                                                 height: -value.velocity.height))
                         } else if let region = cube.region(at: value.location) {
                             controller.goToRegion(region)
                         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.16] — 2026-06-08
+
+### Fixed
+- **Navigation-cube drag direction** (follow-up to #60/v1.1.15). Dragging the cube orbited the camera the wrong way — v1.1.15 reused the viewport's grab-the-model sign, but the cube is a camera proxy, so it must orbit the camera *around* the model (opposite sign on both axes). Dragging the cube now spins the view the way the drag intends.
+
 ## [1.1.15] — 2026-06-08
 
 ### Changed


### PR DESCRIPTION
On-device follow-up: the cube drag-orbit (v1.1.15) spun the wrong way.

The cube is a camera proxy — dragging it should orbit the camera *around* the model, the opposite sign to the viewport’s grab-the-model drag that v1.1.15 reused. Flipped both axes on `handleOrbit`/`endOrbit`. Pure sign change; 142 tests still green. Confirmed reversed on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)