### PR TITLE
feat(measure): tap-to-measure for measurementMode (#68)

### DIFF
--- a/Sources/OCCTSwiftViewport/Picking/MeasurementPicking.swift
+++ b/Sources/OCCTSwiftViewport/Picking/MeasurementPicking.swift
@@ -1,0 +1,43 @@
+// MeasurementPicking.swift
+// ViewportKit
+//
+// Reconstructs a world-space surface point from a GPU pick result, for
+// tap-to-measure interaction.
+
+import simd
+
+extension ViewportBody {
+    /// World-space position where `ray` intersects the triangle at `triangleIndex`,
+    /// accounting for this body's `transform`.
+    ///
+    /// The triangle vertices are looked up from `indices` / `vertexData` (stride 6:
+    /// position + normal), transformed into world space, then intersected with the
+    /// ray via Moller-Trumbore. Returns `nil` if the index is out of range or the
+    /// ray misses the (transformed) triangle.
+    ///
+    /// `triangleIndex` matches `PickResult.triangleIndex` for a `.face` pick.
+    public func worldHitPoint(ray: Ray, triangleIndex: Int) -> SIMD3<Float>? {
+        let stride = 6
+        let base = triangleIndex * 3
+        guard base >= 0, base + 2 < indices.count else { return nil }
+
+        let i0 = Int(indices[base])
+        let i1 = Int(indices[base + 1])
+        let i2 = Int(indices[base + 2])
+
+        func worldVertex(_ idx: Int) -> SIMD3<Float>? {
+            let b = idx * stride
+            guard b + 2 < vertexData.count else { return nil }
+            let local = SIMD4<Float>(vertexData[b], vertexData[b + 1], vertexData[b + 2], 1)
+            let world = transform * local
+            return SIMD3<Float>(world.x, world.y, world.z)
+        }
+
+        guard let v0 = worldVertex(i0),
+              let v1 = worldVertex(i1),
+              let v2 = worldVertex(i2) else { return nil }
+
+        guard let t = ray.intersectsTriangle(v0: v0, v1: v1, v2: v2) else { return nil }
+        return ray.origin + ray.direction * t
+    }
+}

--- a/Sources/OCCTSwiftViewport/Types/Measurement.swift
+++ b/Sources/OCCTSwiftViewport/Types/Measurement.swift
@@ -110,7 +110,7 @@ public struct RadiusMeasurement: Identifiable, Sendable {
 }
 
 /// Mode for measurement interaction.
-public enum MeasurementMode: Sendable {
+public enum MeasurementMode: Sendable, Equatable {
     /// No measurement tool active.
     case none
     /// Measuring point-to-point distance.

--- a/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+++ b/Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
@@ -216,9 +216,17 @@ public struct MetalViewportView: View {
         controller.dispatch(.tap(ndc: ndc, count: 1))
 
         let ctrl = controller
+        let snapshot = bodies
+        let aspect = controller.lastAspectRatio
         renderer?.performPick(at: pixel) { result in
             Task { @MainActor in
-                ctrl.handlePick(result: result, ndc: ndc)
+                // While a measurement tool is active, taps feed the measurement
+                // accumulator instead of the selection stream.
+                if ctrl.measurementMode != .none {
+                    ctrl.handleMeasurementPick(result: result, ndc: ndc, bodies: snapshot, aspectRatio: aspect)
+                } else {
+                    ctrl.handlePick(result: result, ndc: ndc)
+                }
             }
         }
     }

--- a/Sources/OCCTSwiftViewport/Views/ViewportController.swift
+++ b/Sources/OCCTSwiftViewport/Views/ViewportController.swift
@@ -88,7 +88,24 @@ public final class ViewportController: ObservableObject {
     @Published public var measurements: [ViewportMeasurement] = []
 
     /// Current measurement interaction mode.
-    @Published public var measurementMode: MeasurementMode = .none
+    ///
+    /// When set to anything other than `.none`, taps on geometry feed
+    /// `addMeasurementPoint(_:)` instead of the selection stream, accumulating
+    /// points until a measurement is complete (2 for `.distance`/`.radius`,
+    /// 3 for `.angle`). Changing the mode clears any in-progress points.
+    @Published public var measurementMode: MeasurementMode = .none {
+        didSet {
+            if measurementMode != oldValue {
+                pendingMeasurementPoints.removeAll()
+            }
+        }
+    }
+
+    /// World-space points picked so far for the in-progress measurement, in the
+    /// order they were tapped. Cleared when a measurement completes, the mode
+    /// changes, or `cancelPendingMeasurement()` is called. Drives in-progress
+    /// feedback (e.g. a rubber-band line) in the overlay.
+    @Published public private(set) var pendingMeasurementPoints: [SIMD3<Float>] = []
 
     // MARK: - Post-Process Toggles (runtime-tunable)
 
@@ -385,6 +402,96 @@ public final class ViewportController: ObservableObject {
     public func handlePick(result: PickResult?, ndc: SIMD2<Float>) {
         lastPickNDC = ndc
         handlePick(result: result)
+    }
+
+    // MARK: - Measurement Interaction
+
+    /// Number of world points a measurement of the given mode requires before it
+    /// is committed. `.none` returns 0.
+    public nonisolated static func pointCount(for mode: MeasurementMode) -> Int {
+        switch mode {
+        case .none: return 0
+        case .distance, .radius: return 2
+        case .angle: return 3
+        }
+    }
+
+    /// Feeds a world-space point into the active measurement.
+    ///
+    /// Call this from the tap/pick path while `measurementMode != .none` (the
+    /// view layer does this automatically). The point is appended to
+    /// `pendingMeasurementPoints`; once enough points for the current mode have
+    /// been gathered, a `ViewportMeasurement` is appended to `measurements` and
+    /// the pending buffer is cleared, ready for the next measurement. A no-op
+    /// when the mode is `.none`.
+    ///
+    /// Point order per mode:
+    /// - `.distance`: start, end
+    /// - `.angle`: armA, vertex, armB
+    /// - `.radius`: center, edge point
+    public func addMeasurementPoint(_ point: SIMD3<Float>) {
+        guard measurementMode != .none else { return }
+        pendingMeasurementPoints.append(point)
+
+        let needed = ViewportController.pointCount(for: measurementMode)
+        guard pendingMeasurementPoints.count >= needed else { return }
+
+        let pts = pendingMeasurementPoints
+        pendingMeasurementPoints.removeAll()
+
+        switch measurementMode {
+        case .none:
+            break
+        case .distance:
+            measurements.append(.distance(DistanceMeasurement(start: pts[0], end: pts[1])))
+        case .angle:
+            measurements.append(.angle(AngleMeasurement(pointA: pts[0], vertex: pts[1], pointB: pts[2])))
+        case .radius:
+            measurements.append(.radius(RadiusMeasurement(center: pts[0], edgePoint: pts[1])))
+        }
+    }
+
+    /// Routes a GPU pick to the active measurement instead of the selection
+    /// stream, reconstructing the world-space surface point under the tap.
+    ///
+    /// Called by the view layer (in place of `handlePick`) while
+    /// `measurementMode != .none`. Only `.face` picks yield a point; edge/vertex
+    /// picks and misses are ignored. The point is the ray/triangle intersection
+    /// in world space (respecting the body's transform), then fed to
+    /// `addMeasurementPoint(_:)`.
+    public func handleMeasurementPick(
+        result: PickResult?,
+        ndc: SIMD2<Float>,
+        bodies: [ViewportBody],
+        aspectRatio: Float
+    ) {
+        lastPickNDC = ndc
+        guard measurementMode != .none, let result, result.kind == .face else { return }
+
+        let body: ViewportBody?
+        if result.bodyIndex >= 0, result.bodyIndex < bodies.count,
+           bodies[result.bodyIndex].id == result.bodyID {
+            body = bodies[result.bodyIndex]
+        } else {
+            body = bodies.first { $0.id == result.bodyID }
+        }
+        guard let body else { return }
+
+        let ray = Ray.fromCamera(ndc: ndc, cameraState: cameraState, aspectRatio: aspectRatio)
+        guard let point = body.worldHitPoint(ray: ray, triangleIndex: result.triangleIndex) else { return }
+        addMeasurementPoint(point)
+    }
+
+    /// Discards any in-progress measurement points without committing a
+    /// measurement. The mode is left unchanged.
+    public func cancelPendingMeasurement() {
+        pendingMeasurementPoints.removeAll()
+    }
+
+    /// Removes all committed measurements and any in-progress points.
+    public func clearMeasurements() {
+        measurements.removeAll()
+        pendingMeasurementPoints.removeAll()
     }
 
     /// Clears the current selection.

--- a/Tests/OCCTSwiftViewportTests/MeasurementModeTests.swift
+++ b/Tests/OCCTSwiftViewportTests/MeasurementModeTests.swift
@@ -1,0 +1,260 @@
+import Testing
+import simd
+@testable import OCCTSwiftViewport
+
+/// Tap-to-measure interaction (#68): `measurementMode` now drives point
+/// accumulation that commits `ViewportMeasurement`s.
+@Suite("Measurement mode interaction")
+struct MeasurementModeTests {
+
+    // A unit quad in the z=0 plane, centred at the origin, normal +Z, stride-6
+    // interleaved (position + normal). Two triangles: (0,1,2) and (0,2,3).
+    private static func quad(id: String = "quad",
+                             halfExtent h: Float = 2,
+                             transform: simd_float4x4 = matrix_identity_float4x4) -> ViewportBody {
+        let n: SIMD3<Float> = [0, 0, 1]
+        let corners: [SIMD3<Float>] = [[-h, -h, 0], [h, -h, 0], [h, h, 0], [-h, h, 0]]
+        var vertexData: [Float] = []
+        for c in corners {
+            vertexData += [c.x, c.y, c.z, n.x, n.y, n.z]
+        }
+        return ViewportBody(
+            id: id,
+            vertexData: vertexData,
+            indices: [0, 1, 2, 0, 2, 3],
+            edges: [],
+            color: .one,
+            transform: transform
+        )
+    }
+
+    // Decoded face PickResult for body `objectIndex`, triangle `primitiveID`.
+    private static func facePick(objectIndex: UInt32, primitiveID: UInt32, indexMap: [Int: String]) -> PickResult {
+        let raw: UInt32 = (UInt32(PrimitiveKind.face.rawValue) << 30)
+            | ((primitiveID & 0x3FFF) << 16)
+            | (objectIndex & 0xFFFF)
+        return PickResult(rawValue: raw, indexMap: indexMap, layerMap: [:])!
+    }
+
+    // Camera at +Z looking down -Z at the origin (identity rotation).
+    private static func topCamera(distance: Float = 5) -> CameraState {
+        CameraState(rotation: simd_quatf(angle: 0, axis: [0, 0, 1]),
+                    distance: distance,
+                    pivot: .zero)
+    }
+
+    // Column-major translation matrix (simd has no built-in initialiser).
+    private static func translation(_ t: SIMD3<Float>) -> simd_float4x4 {
+        var m = matrix_identity_float4x4
+        m.columns.3 = SIMD4<Float>(t.x, t.y, t.z, 1)
+        return m
+    }
+
+    // MARK: - Point counts
+
+    @Test("pointCount maps each mode to its requirement")
+    func pointCounts() {
+        #expect(ViewportController.pointCount(for: .none) == 0)
+        #expect(ViewportController.pointCount(for: .distance) == 2)
+        #expect(ViewportController.pointCount(for: .radius) == 2)
+        #expect(ViewportController.pointCount(for: .angle) == 3)
+    }
+
+    // MARK: - Accumulation (pure)
+
+    @MainActor
+    @Test("Distance commits after two points and clears pending")
+    func distanceCommits() {
+        let c = ViewportController()
+        c.measurementMode = .distance
+
+        c.addMeasurementPoint([0, 0, 0])
+        #expect(c.measurements.isEmpty)
+        #expect(c.pendingMeasurementPoints.count == 1)
+
+        c.addMeasurementPoint([3, 4, 0])
+        #expect(c.pendingMeasurementPoints.isEmpty)
+        #expect(c.measurements.count == 1)
+        guard case let .distance(m) = c.measurements[0] else {
+            Issue.record("expected a distance measurement"); return
+        }
+        #expect(m.start == [0, 0, 0])
+        #expect(m.end == [3, 4, 0])
+        #expect(abs(m.distance - 5) < 1e-5)
+    }
+
+    @MainActor
+    @Test("Angle commits after three points in armA/vertex/armB order")
+    func angleCommits() {
+        let c = ViewportController()
+        c.measurementMode = .angle
+
+        c.addMeasurementPoint([1, 0, 0])   // armA
+        c.addMeasurementPoint([0, 0, 0])   // vertex
+        #expect(c.measurements.isEmpty)
+        c.addMeasurementPoint([0, 1, 0])   // armB
+
+        #expect(c.measurements.count == 1)
+        guard case let .angle(m) = c.measurements[0] else {
+            Issue.record("expected an angle measurement"); return
+        }
+        #expect(m.pointA == [1, 0, 0])
+        #expect(m.vertex == [0, 0, 0])
+        #expect(m.pointB == [0, 1, 0])
+        #expect(abs(m.degrees - 90) < 1e-3)
+    }
+
+    @MainActor
+    @Test("Radius commits as centre-then-edge")
+    func radiusCommits() {
+        let c = ViewportController()
+        c.measurementMode = .radius
+
+        c.addMeasurementPoint([0, 0, 0])   // centre
+        c.addMeasurementPoint([2, 0, 0])   // edge
+
+        #expect(c.measurements.count == 1)
+        guard case let .radius(m) = c.measurements[0] else {
+            Issue.record("expected a radius measurement"); return
+        }
+        #expect(m.center == [0, 0, 0])
+        #expect(abs(m.radius - 2) < 1e-5)
+    }
+
+    @MainActor
+    @Test("Two distance measurements accumulate independently")
+    func multipleMeasurements() {
+        let c = ViewportController()
+        c.measurementMode = .distance
+        c.addMeasurementPoint([0, 0, 0]); c.addMeasurementPoint([1, 0, 0])
+        c.addMeasurementPoint([0, 0, 0]); c.addMeasurementPoint([0, 2, 0])
+        #expect(c.measurements.count == 2)
+        #expect(c.pendingMeasurementPoints.isEmpty)
+    }
+
+    // MARK: - Mode gating & cancellation
+
+    @MainActor
+    @Test("addMeasurementPoint is a no-op when mode is .none")
+    func noneIgnores() {
+        let c = ViewportController()
+        c.addMeasurementPoint([0, 0, 0])
+        #expect(c.pendingMeasurementPoints.isEmpty)
+        #expect(c.measurements.isEmpty)
+    }
+
+    @MainActor
+    @Test("Changing mode discards in-progress points")
+    func modeChangeClearsPending() {
+        let c = ViewportController()
+        c.measurementMode = .distance
+        c.addMeasurementPoint([0, 0, 0])
+        #expect(c.pendingMeasurementPoints.count == 1)
+
+        c.measurementMode = .angle
+        #expect(c.pendingMeasurementPoints.isEmpty)
+        #expect(c.measurements.isEmpty)
+    }
+
+    @MainActor
+    @Test("cancelPendingMeasurement keeps the mode, drops points")
+    func cancelKeepsMode() {
+        let c = ViewportController()
+        c.measurementMode = .distance
+        c.addMeasurementPoint([0, 0, 0])
+        c.cancelPendingMeasurement()
+        #expect(c.pendingMeasurementPoints.isEmpty)
+        #expect(c.measurementMode == .distance)
+    }
+
+    @MainActor
+    @Test("clearMeasurements removes committed and pending")
+    func clearAll() {
+        let c = ViewportController()
+        c.measurementMode = .distance
+        c.addMeasurementPoint([0, 0, 0]); c.addMeasurementPoint([1, 0, 0]) // 1 committed
+        c.addMeasurementPoint([0, 0, 0]) // 1 pending
+        c.clearMeasurements()
+        #expect(c.measurements.isEmpty)
+        #expect(c.pendingMeasurementPoints.isEmpty)
+    }
+
+    // MARK: - World-point reconstruction
+
+    @Test("worldHitPoint intersects the picked triangle in world space")
+    func worldHitPointIdentity() {
+        let body = Self.quad()
+        // Ray straight down -Z through the origin hits the quad at (0,0,0).
+        let ray = Ray(origin: [0, 0, 5], direction: [0, 0, -1])
+        let p = body.worldHitPoint(ray: ray, triangleIndex: 0)
+        #expect(p != nil)
+        if let p {
+            #expect(abs(p.x) < 1e-5 && abs(p.y) < 1e-5 && abs(p.z) < 1e-5)
+        }
+    }
+
+    @Test("worldHitPoint respects the body transform")
+    func worldHitPointTransformed() {
+        let t = Self.translation([10, 0, 0])
+        let body = Self.quad(transform: t)
+        // The quad now spans x∈[8,12]; a ray at x=0 misses, x=10 hits.
+        #expect(body.worldHitPoint(ray: Ray(origin: [0, 0, 5], direction: [0, 0, -1]), triangleIndex: 0) == nil)
+        let hit = body.worldHitPoint(ray: Ray(origin: [10, 0, 5], direction: [0, 0, -1]), triangleIndex: 0)
+        #expect(hit != nil)
+        if let hit { #expect(abs(hit.x - 10) < 1e-5 && abs(hit.z) < 1e-5) }
+    }
+
+    @Test("worldHitPoint returns nil for an out-of-range triangle")
+    func worldHitPointOutOfRange() {
+        let body = Self.quad()
+        #expect(body.worldHitPoint(ray: Ray(origin: [0, 0, 5], direction: [0, 0, -1]), triangleIndex: 99) == nil)
+    }
+
+    // MARK: - End-to-end pick routing
+
+    @MainActor
+    @Test("handleMeasurementPick reconstructs and accumulates surface points")
+    func pickRoutingCommitsDistance() {
+        let c = ViewportController()
+        c.animateTo(Self.topCamera(), duration: 0)
+        c.measurementMode = .distance
+        let bodies = [Self.quad()]
+        let map: [Int: String] = [0: "quad"]
+
+        // Two off-centre face taps land on distinct points of the quad.
+        c.handleMeasurementPick(result: Self.facePick(objectIndex: 0, primitiveID: 0, indexMap: map),
+                                ndc: [0.2, -0.2], bodies: bodies, aspectRatio: 1)
+        #expect(c.pendingMeasurementPoints.count == 1)
+
+        c.handleMeasurementPick(result: Self.facePick(objectIndex: 0, primitiveID: 1, indexMap: map),
+                                ndc: [-0.2, 0.2], bodies: bodies, aspectRatio: 1)
+
+        #expect(c.measurements.count == 1)
+        guard case let .distance(m) = c.measurements[0] else {
+            Issue.record("expected a distance measurement"); return
+        }
+        #expect(m.distance > 0)             // the two taps were distinct points
+        #expect(abs(m.start.z) < 1e-4)      // both lie on the z=0 quad
+        #expect(abs(m.end.z) < 1e-4)
+    }
+
+    @MainActor
+    @Test("handleMeasurementPick ignores misses and non-face picks")
+    func pickRoutingIgnoresNonFace() {
+        let c = ViewportController()
+        c.animateTo(Self.topCamera(), duration: 0)
+        c.measurementMode = .distance
+        let bodies = [Self.quad()]
+        let map: [Int: String] = [0: "quad"]
+
+        // A miss (nil) does nothing.
+        c.handleMeasurementPick(result: nil, ndc: .zero, bodies: bodies, aspectRatio: 1)
+        #expect(c.pendingMeasurementPoints.isEmpty)
+
+        // An edge pick (not a surface) does nothing.
+        let edgeRaw = (UInt32(PrimitiveKind.edge.rawValue) << 30) | 0
+        let edge = PickResult(rawValue: edgeRaw, indexMap: map, layerMap: [:])!
+        c.handleMeasurementPick(result: edge, ndc: .zero, bodies: bodies, aspectRatio: 1)
+        #expect(c.pendingMeasurementPoints.isEmpty)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OCCTSwiftViewport are documented in this file.
 
+## [1.1.20] — 2026-06-12
+
+### Added
+- **Tap-to-measure** (issue #68). `ViewportController.measurementMode` (`.distance` / `.angle` / `.radius`) now actually drives interaction: while a mode is active, taps on geometry accumulate world-space surface points and commit a `ViewportMeasurement` (rendered by the existing `MeasurementOverlay`). Previously the property was published but consumed by nothing, so setting it did nothing — it read like a feature that silently didn't work.
+  - Point order per mode: `.distance` → start, end (2 taps); `.angle` → armA, vertex, armB (3 taps); `.radius` → center, edge (2 taps).
+  - New `ViewportBody.worldHitPoint(ray:triangleIndex:)` reconstructs the picked surface point in world space, **respecting the body's `transform`**.
+  - New controller surface: `pendingMeasurementPoints` (published, for in-progress feedback), `addMeasurementPoint(_:)`, `handleMeasurementPick(result:ndc:bodies:aspectRatio:)`, `cancelPendingMeasurement()`, `clearMeasurements()`, and `static pointCount(for:)`. Changing the mode clears in-progress points; taps register on `.face` picks only and don't disturb the selection stream.
+  - `MeasurementMode` is now `Equatable`.
+- New `MeasurementModeTests` (14). 160 tests total.
+
 ## [1.1.16] — 2026-06-08
 
 ### Fixed


### PR DESCRIPTION
Closes #68.

`ViewportController.measurementMode` was published but consumed by nothing — setting it to `.distance`/`.angle`/`.radius` did nothing, which read like a tap-to-measure feature that silently didn't work. This wires it up.

## What changed
While a measurement mode is active, taps on geometry accumulate world-space surface points and commit a `ViewportMeasurement`, which the existing `MeasurementOverlay` already renders.

- **Point order per mode:** `.distance` → start, end (2 taps); `.angle` → armA, vertex, armB (3 taps); `.radius` → center, edge (2 taps).
- **New** `ViewportBody.worldHitPoint(ray:triangleIndex:)` — reconstructs the picked surface point in world space, **respecting the body's `transform`** (the demo's old `GeometryUtils` didn't).
- **New controller surface:** `pendingMeasurementPoints` (published, for in-progress feedback), `addMeasurementPoint(_:)`, `handleMeasurementPick(result:ndc:bodies:aspectRatio:)`, `cancelPendingMeasurement()`, `clearMeasurements()`, `static pointCount(for:)`.
- Changing the mode clears in-progress points; taps register on `.face` picks only and don't disturb the selection stream.
- `MeasurementMode` is now `Equatable`.

## Tests
New `MeasurementModeTests` (14): per-mode commit + point order, mode-change clears pending, cancel/clear, world-point reconstruction (incl. transform + out-of-range), end-to-end pick routing (incl. miss/non-face gating). **160 tests total, all green.**

## Notes
- `pendingMeasurementPoints` is exposed so a host (or a future overlay tweak) can draw a rubber-band line for the in-progress measurement; this PR doesn't draw it — committed measurements render via the existing path.
- Additive, source-compatible. No demo UI added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)