### PR TITLE
feat(display): unlit/flat-colour DisplayMode for faithful diagnostic renders (closes #77)

### DIFF
--- a/Sources/OCCTSwiftViewport/Display/DisplayMode.swift
+++ b/Sources/OCCTSwiftViewport/Display/DisplayMode.swift
@@ -23,6 +23,12 @@ public enum DisplayMode: String, CaseIterable, Sendable {
     /// Flat shading without smooth interpolation.
     case flat
 
+    /// Unlit / flat-colour rendering — each body drawn in its constant base colour
+    /// with no lighting, ambient, shadows, fresnel, or tone mapping. Intended for
+    /// diagnostic / debug renders where faithful, distinguishable per-body colours
+    /// matter more than realistic shading (issue #77).
+    case unlit
+
     /// X-ray mode - transparent with visible internal edges.
     case xray
 
@@ -38,6 +44,7 @@ public enum DisplayMode: String, CaseIterable, Sendable {
         case .shaded: return "Shaded"
         case .shadedWithEdges: return "Shaded + Edges"
         case .flat: return "Flat"
+        case .unlit: return "Unlit"
         case .xray: return "X-Ray"
         case .rendered: return "Rendered"
         }
@@ -48,7 +55,7 @@ public enum DisplayMode: String, CaseIterable, Sendable {
         switch self {
         case .wireframe:
             return false
-        case .shaded, .shadedWithEdges, .flat, .xray, .rendered:
+        case .shaded, .shadedWithEdges, .flat, .unlit, .xray, .rendered:
             return true
         }
     }
@@ -58,7 +65,7 @@ public enum DisplayMode: String, CaseIterable, Sendable {
         switch self {
         case .wireframe, .shadedWithEdges, .xray:
             return true
-        case .shaded, .flat, .rendered:
+        case .shaded, .flat, .unlit, .rendered:
             return false
         }
     }
@@ -68,7 +75,7 @@ public enum DisplayMode: String, CaseIterable, Sendable {
         switch self {
         case .flat:
             return false
-        case .wireframe, .shaded, .shadedWithEdges, .xray, .rendered:
+        case .wireframe, .shaded, .shadedWithEdges, .unlit, .xray, .rendered:
             return true
         }
     }

--- a/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
@@ -447,7 +447,8 @@ public final class OffscreenRenderer: Sendable {
                 lightViewProjectionMatrix: lightVP,
                 shadowParams: shadowParams,
                 shadowParams2: shadowParams2,
-                iblParams: .zero
+                iblParams: .zero,
+                unlit: options.displayMode == .unlit ? 1 : 0
             )
         }
 

--- a/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
+++ b/Sources/OCCTSwiftViewport/Renderer/Shaders.metal
@@ -32,7 +32,8 @@ struct Uniforms {
                                        // z = backgroundExposure, w = hasEnvMap (>0.5)
     float4   clipPlanes[4];            // xyz = normal, w = distance (dot(N,P)+w < 0 → clip)
     uint     clipPlaneCount;           // number of active clip planes (0–4)
-    float3   _clipPad;                 // padding to 16-byte alignment
+    uint     unlit;                    // 1 = unlit/flat-colour (skip lighting + tone map)
+    float2   _clipPad;                 // padding to 16-byte alignment
 };
 
 // IMPORTANT — Swift↔Metal sync (see Renderer/ViewportRenderer.swift `struct BodyUniforms`).
@@ -280,6 +281,22 @@ fragment ShadedFragmentOut shaded_fragment(
         if (dot(plane.xyz, in.worldPosition) + plane.w < 0.0) {
             discard_fragment();
         }
+    }
+
+    // Unlit / flat-colour mode (issue #77): emit the body's base colour directly,
+    // skipping all lighting, ambient, shadows, fresnel, curvature and tone mapping —
+    // so vivid diagnostic colours stay faithful and distinguishable. Clip planes and
+    // selection tint still apply.
+    if (uniforms.unlit != 0u) {
+        float3 flatColor = bodyUniforms.color.rgb;
+        if (bodyUniforms.isSelected == 1) {
+            flatColor = mix(flatColor, float3(0.3, 0.5, 1.0), 0.15);
+        } else if (bodyUniforms.isSelected == 2) {
+            flatColor = mix(flatColor, float3(0.4, 0.6, 1.0), 0.08);
+        }
+        ShadedFragmentOut unlitOut;
+        unlitOut.color = float4(flatColor, bodyUniforms.color.a);
+        return unlitOut;
     }
 
     float3 N = normalize(in.worldNormal);

--- a/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
@@ -34,7 +34,8 @@ struct Uniforms {
                                               // z = backgroundExposure, w = hasEnvMap
     var clipPlanes: (SIMD4<Float>, SIMD4<Float>, SIMD4<Float>, SIMD4<Float>) = (.zero, .zero, .zero, .zero)
     var clipPlaneCount: UInt32 = 0
-    var _clipPad: SIMD3<Float> = .zero
+    var unlit: UInt32 = 0                      // 1 = unlit/flat-colour (skip lighting + tone map)
+    var _clipPad: SIMD2<Float> = .zero
 }
 
 // Per-body shader uniforms.
@@ -1274,7 +1275,8 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
                 shadowParams2: shadowParams2,
                 iblParams: iblParams,
                 clipPlanes: clipPlaneVecs,
-                clipPlaneCount: clipPlaneCount
+                clipPlaneCount: clipPlaneCount,
+                unlit: controller.displayMode == .unlit ? 1 : 0
             )
         }
 
@@ -1314,7 +1316,9 @@ public final class ViewportRenderer: NSObject, MTKViewDelegate, Sendable {
             : nil
 
         let silhouettesEnabled = controller.configuration.enableSilhouettes
-        let ssaoEnabled = (lighting.enableSSAO || silhouettesEnabled) && ssaoPipeline != nil && displayMode.showsSurfaces
+        // Unlit mode bypasses the SSAO/tone-map composite pass entirely so diagnostic
+        // colours are never desaturated by ACES tone mapping (issue #77).
+        let ssaoEnabled = (lighting.enableSSAO || silhouettesEnabled) && ssaoPipeline != nil && displayMode.showsSurfaces && displayMode != .unlit
         let taaEnabled = controller.enableTAA && taaPipeline != nil
         let w = Int(drawableSize.width)
         let h = Int(drawableSize.height)

--- a/Tests/OCCTSwiftViewportTests/UnlitColorTests.swift
+++ b/Tests/OCCTSwiftViewportTests/UnlitColorTests.swift
@@ -1,0 +1,104 @@
+// UnlitColorTests.swift
+// OCCTSwiftViewport Tests
+//
+// Unlit / flat-colour display mode (issue #77). Headless render: a vivid magenta
+// panel rendered with `.unlit` must reproduce its base colour faithfully (no
+// lighting / ambient / fresnel / tone-map desaturation), where `.shaded` washes
+// it out toward grey/green.
+
+import Testing
+import simd
+import CoreGraphics
+@testable import OCCTSwiftViewport
+
+@MainActor
+@Suite("Unlit display mode")
+struct UnlitColorTests {
+
+    // Camera at +Z (identity rotation) looking down -Z at the origin.
+    private let camera = CameraState(
+        rotation: simd_quatf(angle: 0, axis: SIMD3<Float>(0, 0, 1)),
+        distance: 10,
+        pivot: .zero
+    )
+
+    // A vivid magenta — the diagnostic colour from the issue that `.shaded` desaturates.
+    private let magenta = SIMD4<Float>(1.0, 0.15, 0.85, 1.0)
+
+    /// A flat quad at depth `z` facing +Z (toward the camera), covering the centre.
+    /// Positions are baked in because `OffscreenRenderer` doesn't apply `body.transform`.
+    private func panel(color: SIMD4<Float>) -> ViewportBody {
+        let z: Float = 3, half: Float = 3
+        func v(_ x: Float, _ y: Float) -> [Float] { [x, y, z, 0, 0, 1] }
+        let verts = v(-half, -half) + v(half, -half) + v(half, half) + v(-half, half)
+        let idx: [UInt32] = [0, 1, 2, 0, 2, 3]
+        return ViewportBody(id: "panel", vertexData: verts, indices: idx, edges: [], color: color)
+    }
+
+    @Test("Unlit mode reproduces the body's base colour faithfully (#77)")
+    func unlitIsFaithful() throws {
+        guard let renderer = OffscreenRenderer() else {
+            Issue.record("Metal device unavailable; skipping headless render test")
+            return
+        }
+        let base = OffscreenRenderOptions(width: 64, height: 64, cameraState: camera,
+                                          backgroundColor: SIMD4<Float>(0, 0, 0, 1))
+        var unlitOpts = base; unlitOpts.displayMode = .unlit
+        var shadedOpts = base; shadedOpts.displayMode = .shaded
+
+        guard let unlitImg = renderer.render(bodies: [panel(color: magenta)], options: unlitOpts),
+              let shadedImg = renderer.render(bodies: [panel(color: magenta)], options: shadedOpts) else {
+            Issue.record("renderer returned nil image")
+            return
+        }
+
+        let (ur, ug, ub) = centerPixel(unlitImg)
+        let (sr, sg, sb) = centerPixel(shadedImg)
+
+        // Unlit centre is the source magenta (≈ 255, 38, 217), within tolerance:
+        // red & blue dominant, green clearly the smallest channel.
+        #expect(ur > 200, "unlit red should be high, got \(ur)")
+        #expect(ub > 170, "unlit blue should be high, got \(ub)")
+        #expect(ug < 90, "unlit green should be low, got \(ug)")
+        #expect(ur - ug > 110 && ub - ug > 70,
+                "unlit pixel should read as magenta, got (\(ur),\(ug),\(ub))")
+
+        // Unlit preserves far more saturation than shaded (the whole point of #77).
+        let satUnlit = max(ur, ug, ub) - min(ur, ug, ub)
+        let satShaded = max(sr, sg, sb) - min(sr, sg, sb)
+        #expect(satUnlit > satShaded,
+                "unlit should be more saturated than shaded; unlit=\(satUnlit) shaded=\(satShaded) (unlit rgb \(ur),\(ug),\(ub) / shaded rgb \(sr),\(sg),\(sb))")
+    }
+
+    // MARK: - Helpers
+
+    /// (r, g, b) of the centre pixel, 0–255.
+    private func centerPixel(_ image: CGImage) -> (Int, Int, Int) {
+        let (buffer, width, height) = readBGRA(image)
+        let bytesPerRow = width * 4
+        let x = width / 2, y = height / 2
+        let i = y * bytesPerRow + x * 4
+        return (Int(buffer[i + 2]), Int(buffer[i + 1]), Int(buffer[i]))
+    }
+
+    private func readBGRA(_ image: CGImage) -> ([UInt8], Int, Int) {
+        let width = image.width
+        let height = image.height
+        let bytesPerRow = width * 4
+        var buffer = [UInt8](repeating: 0, count: bytesPerRow * height)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue:
+            CGImageAlphaInfo.premultipliedFirst.rawValue |
+            CGBitmapInfo.byteOrder32Little.rawValue)
+        buffer.withUnsafeMutableBytes { raw in
+            if let ctx = CGContext(
+                data: raw.baseAddress, width: width, height: height,
+                bitsPerComponent: 8, bytesPerRow: bytesPerRow,
+                space: colorSpace, bitmapInfo: bitmapInfo.rawValue
+            ) {
+                ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            }
+        }
+        return (buffer, width, height)
+    }
+}


### PR DESCRIPTION
Closes #77.

## Problem
`OffscreenRenderer` `.shaded` runs every body through the full PBR path — hemisphere ambient (bluish sky), Fresnel white rim, screen-space curvature, and (interactively) ACES tone mapping. Vivid per-body colors get desaturated and hue-shifted: a bright magenta `(1.0, 0.15, 0.85)` reads as green-ish and is indistinguishable from a green body. For colour-coded **diagnostic / debug renders** (e.g. OCCTReconstruct's region maps), the colour coding is the whole point and it's getting lost.

## Fix — `DisplayMode.unlit`
A true unlit / flat-colour mode: each body is drawn in its constant base colour with **no lighting, ambient, shadows, fresnel, curvature, or tone mapping**.

- `shaded_fragment` early-returns `bodyUniforms.color` when the new `Uniforms.unlit` flag is set (clip-plane discard + selection tint still apply).
- Both `OffscreenRenderer` and `ViewportRenderer` set the flag from their `displayMode` (`.unlit` routes through the shaded pipeline via `showsSurfaces == true`).
- The interactive SSAO / ACES tone-map post-pass is skipped for `.unlit`, so it can never re-desaturate.
- `Uniforms` gains a `uint unlit` field, kept in sync Swift↔Metal by repacking the existing 16-byte clip-pad tail (stride unchanged elsewhere).

Note: the issue's request #2 (configurable lighting) already partly exists — `OffscreenRenderOptions.lightingConfiguration` is settable and there's a `LightingConfiguration.flat` preset — but it still applies a key light and tone-maps, so `.unlit` is the faithful fix.

## Verification
- New `UnlitColorTests`: a magenta panel renders faithfully in `.unlit` (R≈255, G≈38, B≈217) and is measurably more saturated than `.shaded`.
- **161 tests pass** — the `Uniforms` repack broke no existing render test; demo builds against the new enum case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
