### PR TITLE
fix(normals): average input vertex normals, not face normals (closes #81)

### DIFF
--- a/Sources/OCCTSwiftViewport/Renderer/NormalSmoothing.swift
+++ b/Sources/OCCTSwiftViewport/Renderer/NormalSmoothing.swift
@@ -32,8 +32,17 @@ public enum NormalSmoothing {
 
         let cosCrease = cos(creaseAngle)
 
-        // --- Step 1: Compute face normals (area-weighted) ---
+        // Snapshot the INPUT per-vertex normals before any in-place write. The fix for #81 is to
+        // average THESE within each crease group — preserving OCCT's accurate analytic B-rep
+        // normals — rather than recomputing from face normals. The face-normal average is
+        // directionally biased on highly anisotropic meshes (long thin triangles along a sweep,
+        // e.g. helical thread flanks) and shows up as fine "brushed" striations. Face normals are
+        // still used below for crease *detection* (hard-edge preservation).
+        let originalNormals: [SIMD3<Float>] = (0..<vertexCount).map { normal(vertexData, $0) }
+
+        // --- Step 1: Compute face normals + triangle areas (areas weight the average) ---
         var faceNormals = [SIMD3<Float>](repeating: .zero, count: triangleCount)
+        var faceAreas = [Float](repeating: 0, count: triangleCount)
         for t in 0..<triangleCount {
             let i0 = Int(indices[t * 3])
             let i1 = Int(indices[t * 3 + 1])
@@ -44,6 +53,7 @@ public enum NormalSmoothing {
             let cross = simd_cross(p1 - p0, p2 - p0)
             let len = simd_length(cross)
             faceNormals[t] = len > 1e-12 ? cross / len : .zero
+            faceAreas[t] = len * 0.5
         }
 
         // --- Step 2: Build spatial hash of vertex positions ---
@@ -93,17 +103,21 @@ public enum NormalSmoothing {
                 cosThreshold: cosCrease
             )
 
-            // For each group, compute averaged normal and assign to member vertices
+            // For each crease group, assign the area-weighted average of the ORIGINAL per-vertex
+            // normals of this position's vertices in the group (#81). For a smooth B-rep mesh those
+            // input normals are ~equal, so the average reproduces them (striations gone); for a flat
+            // mesh each vertex normal == its own face normal, so this reduces to the previous
+            // area-weighted face-normal average (backward-compatible).
             for group in groups {
-                // Area-weighted average of face normals in this group
+                let groupSet = Set(group)
+
                 var sum = SIMD3<Float>.zero
-                for triIdx in group {
-                    sum += faceNormals[triIdx]
+                for entry in entries where groupSet.contains(entry.triIdx) {
+                    sum += faceAreas[entry.triIdx] * originalNormals[entry.vertexIdx]
                 }
                 let averaged = simd_length(sum) > 1e-12 ? simd_normalize(sum) : faceNormals[group[0]]
 
                 // Assign to all vertices at this position that belong to triangles in this group
-                let groupSet = Set(group)
                 for entry in entries where groupSet.contains(entry.triIdx) {
                     let vIdx = entry.vertexIdx
                     if !processed[vIdx] {
@@ -122,6 +136,12 @@ public enum NormalSmoothing {
     /// Extracts position from interleaved vertex data.
     private static func position(_ data: [Float], _ idx: Int) -> SIMD3<Float> {
         let base = idx * 6
+        return SIMD3<Float>(data[base], data[base + 1], data[base + 2])
+    }
+
+    /// Extracts the per-vertex normal from interleaved vertex data.
+    private static func normal(_ data: [Float], _ idx: Int) -> SIMD3<Float> {
+        let base = idx * 6 + 3
         return SIMD3<Float>(data[base], data[base + 1], data[base + 2])
     }
 

--- a/Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift
+++ b/Tests/OCCTSwiftViewportTests/NormalSmoothingTests.swift
@@ -21,6 +21,22 @@ struct NormalSmoothingTests {
         return data
     }
 
+    /// Builds an interleaved buffer from explicit (position, normal) pairs — used to
+    /// model the per-vertex normals a real B-rep mesher (OCCT `BRepMesh`) supplies,
+    /// which the #81 fix must preserve.
+    private func interleaved(_ verts: [(p: SIMD3<Float>, n: SIMD3<Float>)]) -> [Float] {
+        var data: [Float] = []
+        data.reserveCapacity(verts.count * 6)
+        for v in verts {
+            data += [v.p.x, v.p.y, v.p.z, v.n.x, v.n.y, v.n.z]
+        }
+        return data
+    }
+
+    private func normalAt(_ d: [Float], _ v: Int) -> SIMD3<Float> {
+        SIMD3(d[v * 6 + 3], d[v * 6 + 4], d[v * 6 + 5])
+    }
+
     // MARK: - Regression: issue #30 — quantize() must not trap
 
     @Test("Vertex beyond the ±21,474.8 welding-scale ceiling does not trap")
@@ -81,16 +97,16 @@ struct NormalSmoothingTests {
         // face A in the z=0 plane, face B in the x=0 plane. v0 (face A) and v3
         // (face B) sit at the same position, so smoothing either splits them
         // (sharp) or merges them (smooth) depending on the crease angle.
+        // Seed each face's vertices with that face's true normal — the per-vertex normals a
+        // real mesher supplies. Face A (z=0 plane) → +Z; face B (x=0 plane) → +X.
         func build() -> [Float] {
             interleaved([
-                SIMD3(0, 0, 0), SIMD3(0, 1, 0), SIMD3(1, 0, 0),   // face A
-                SIMD3(0, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1),   // face B
+                (SIMD3(0, 0, 0), SIMD3(0, 0, 1)), (SIMD3(0, 1, 0), SIMD3(0, 0, 1)), (SIMD3(1, 0, 0), SIMD3(0, 0, 1)),   // face A
+                (SIMD3(0, 0, 0), SIMD3(1, 0, 0)), (SIMD3(0, 1, 0), SIMD3(1, 0, 0)), (SIMD3(0, 0, 1), SIMD3(1, 0, 0)),   // face B
             ])
         }
         let indices: [UInt32] = [0, 1, 2, 3, 4, 5]
-        func normal(_ d: [Float], _ v: Int) -> SIMD3<Float> {
-            SIMD3(d[v * 6 + 3], d[v * 6 + 4], d[v * 6 + 5])
-        }
+        func normal(_ d: [Float], _ v: Int) -> SIMD3<Float> { normalAt(d, v) }
 
         // Sharp: 45° crease < 90° ridge → the shared-position normals stay split,
         // each axis-aligned to its own face.
@@ -110,5 +126,54 @@ struct NormalSmoothingTests {
         #expect(simd_length(aSmooth - bSmooth) < 1e-3)         // merged (same normal)
         let blendComps = [abs(aSmooth.x), abs(aSmooth.y), abs(aSmooth.z)].filter { $0 > 0.3 }
         #expect(blendComps.count >= 2)                         // blended across faces
+    }
+
+    // MARK: - #81 — preserve the mesher's per-vertex normals (no brushed striations)
+
+    /// The fix for #81: within a smooth crease group, the assigned normal is the (area-weighted)
+    /// average of the INPUT per-vertex normals, NOT a recomputed face-normal average. So smooth
+    /// analytic normals from OCCT survive smoothing instead of being replaced by a biased
+    /// face-average (the cause of the "brushed" striations on thread flanks).
+    @Test("Smooth per-vertex input normals are preserved, not replaced by the face normal (#81)")
+    func smoothInputNormalsPreserved() {
+        // A flat quad in the z=0 plane (so both face normals are +Z), but every vertex is seeded
+        // with a *tilted* smooth normal N — as if these triangles were a patch of a curved surface
+        // the mesher gave analytic normals for. The thin triangles echo the anisotropic thread-flank
+        // case from #81. The old code would overwrite N with the +Z face normal; the fix keeps N.
+        let N = simd_normalize(SIMD3<Float>(0.30, 0.40, 0.866))
+        var data = interleaved([
+            (SIMD3(0, 0, 0), N), (SIMD3(8, 0, 0), N), (SIMD3(0, 0.4, 0), N),  // thin triangle
+            (SIMD3(8, 0, 0), N), (SIMD3(8, 0.4, 0), N), (SIMD3(0, 0.4, 0), N),
+        ])
+        NormalSmoothing.smoothNormals(vertexData: &data, indices: [0, 1, 2, 3, 4, 5])
+
+        // Every vertex's normal should still be N (the smooth input), not the +Z face normal.
+        for v in 0..<6 {
+            let n = normalAt(data, v)
+            #expect(simd_length(n - N) < 1e-4, "vertex \(v) normal \(n) drifted from input \(N)")
+        }
+    }
+
+    /// Backward-compatibility: for a flat mesh (each vertex normal == its own face normal, e.g.
+    /// imported STL), the area-weighted average of the input vertex normals equals the old
+    /// area-weighted face-normal average — so behaviour is unchanged.
+    @Test("Flat mesh (vertex normal == face normal) reduces to the face-normal average (#81)")
+    func flatInputMatchesFaceNormalAverage() {
+        // The two faces from the crease test (A in z=0 → +Z, B in x=0 → +X), each vertex seeded
+        // with ITS OWN face normal (flat-shaded input). With a wide crease angle they form one
+        // group, so v0/v3 must merge to the equal-area average of the two face normals — i.e. the
+        // exact result the old face-normal averaging produced. Equal triangle areas (both 0.5).
+        let nA = SIMD3<Float>(0, 0, 1)   // face A normal
+        let nB = SIMD3<Float>(1, 0, 0)   // face B normal
+        var data = interleaved([
+            (SIMD3(0, 0, 0), nA), (SIMD3(0, 1, 0), nA), (SIMD3(1, 0, 0), nA),   // face A (z=0)
+            (SIMD3(0, 0, 0), nB), (SIMD3(0, 1, 0), nB), (SIMD3(0, 0, 1), nB),   // face B (x=0)
+        ])
+        NormalSmoothing.smoothNormals(vertexData: &data, indices: [0, 1, 2, 3, 4, 5], creaseAngle: 2.094)
+
+        let expected = simd_normalize(nA + nB)                 // (0.707, 0, 0.707)
+        let merged = normalAt(data, 0)
+        #expect(simd_length(merged - expected) < 1e-4, "flat-input merge \(merged) != face avg \(expected)")
+        #expect(simd_length(normalAt(data, 3) - expected) < 1e-4)
     }
 }


### PR DESCRIPTION
Closes #81 (root cause of OCCTSwift#255).

## Problem
`NormalSmoothing.smoothNormals` (used by `CADFileLoader.shapeToBodyAndMetadata` and both renderers) **discarded the per-vertex normals it was handed and recomputed each from an area-weighted *face*-normal average**. On a highly anisotropic mesh — long thin triangles running along a sweep, e.g. a `threadedShaft` helical flank — that face-average is directionally biased and renders as fine periodic **"brushed" striations**. It looks like a geometric ripple but it's purely shading. OCCT's `BRepMesh` already supplies accurate analytic per-vertex normals; the smoother was overwriting them with something worse.

## Fix
Within each crease group, assign the **area-weighted average of the original per-vertex normals** (snapshotted before the in-place write), instead of recomputing from face normals. Face normals are still used for crease *detection* (hard-edge preservation) — so sharp edges stay crisp.

- **Smooth B-rep meshes:** OCCT's analytic normals are ~equal at a shared position, so the average reproduces them → striations gone.
- **Flat meshes (imported STL, vertex normal == face normal):** the vertex-normal average equals the old face-normal average → **behaviour unchanged, backward-compatible**.

## Tests
- New `smoothInputNormalsPreserved` — a patch seeded with a tilted smooth normal on thin (anisotropic) triangles: the output keeps the smooth input, not the face normal. (Fails on old code, passes now — the #81 regression guard.)
- New `flatInputMatchesFaceNormalAverage` — flat-shaded input reduces to the old face-normal average.
- Updated the existing crease test to seed realistic per-face normals (what a mesher provides) rather than a uniform placeholder.
- **163 tests pass.**

## Notes
- This is the render-side root cause; the in-progress **"direct-mesh render path (Option A)" spike** (de-interleaved OCCT normals straight to the GPU, skipping this pass entirely) addresses the same issue from the other direction and would also resolve #255.
- Perf aside from the issue still stands: `NormalSmoothing` is O(triangles) with a per-position flood-fill and is slow on fine thread meshes — the direct path is the way to skip it; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
