### PR TITLE
standard: add issue-tracking policy doc (5th mandatory OKF policy)

### DIFF
--- a/okf/index.md
+++ b/okf/index.md
@@ -48,3 +48,4 @@ changelog, the Swift Package Index page, and OpenCASCADE upstream.
 - [No em-dashes, banned words in prose](policies/writing-style.md)
 - [Search before building](policies/search-before-building.md)
 - [Code structure](policies/code-structure.md)
+- [Issue labels and project-board tracking](policies/issue-tracking.md)

--- a/okf/policies/issue-tracking.md
+++ b/okf/policies/issue-tracking.md
@@ -1,0 +1,53 @@
+---
+type: policy
+title: Issue labels and project-board tracking
+description: Every issue carries a type:* and priority:* label; a multi-phase initiative gets tracked on its own dedicated project board rather than folded into the repo's default backlog view.
+tags: [policy, issues, labels, project-board, triage]
+timestamp: 2026-08-04
+---
+
+# Issue labels and project-board tracking
+
+**Every issue carries two labels**: a `type:*` (`type:bug`, `type:feature`, `type:chore`,
+`type:epic`, `type:spike`, `type:docs`) and a `priority:*` (`priority:P0` through `priority:P3`).
+This is what makes a backlog scannable instead of a flat list, and it is cheap to keep true:
+setting the pair at triage time takes seconds, and skipping it lets the whole backlog rot back
+into an undifferentiated list within a few dozen issues.
+
+Point the repo's own issue-form templates (`.github/ISSUE_TEMPLATE/`), if it has any, at these
+`type:*` labels directly rather than GitHub's legacy `bug`/`enhancement` defaults, so a
+template-filed issue already carries a correct `type:*` on arrival. Where the volume of issues
+justifies it, enforce the pair with a lightweight, non-blocking GitHub Action rather than trusting
+habit — reference implementation:
+[OCCTSwift#471](https://github.com/SecondMouseAU/OCCTSwift/pull/471) (a first-party
+`actions/github-script` step that posts and updates a sticky comment naming any missing label,
+including on blank issues that bypass the template dropdowns). Not every repo needs this wired up
+immediately; the labels themselves are the mandatory part, the Action is a low-cost addition once
+issue volume makes manual triage unreliable.
+
+**A multi-phase initiative gets a dedicated project board, scoped to its own issues.** A refactor,
+migration, or audit large enough to span several tracked sub-issues (an "epic" in the `type:epic`
+sense) needs a GitHub Project with a `Status` field reflecting that initiative's real workflow
+stages, not the generic Todo/In Progress/Done default — for example Backlog, In Progress, PR
+Review, Code-Review, Ready, Done. Create it as its own project rather than repurposing an existing
+ecosystem-wide board: a shared board's `Status` field is load-bearing for every other item already
+on it, and replacing its options to fit one initiative breaks the view for everything else tracked
+there. Add only the initiative's own issues, not the repo's whole backlog. Reference
+implementation: [OCCTSwift #377](https://github.com/SecondMouseAU/OCCTSwift/issues/377) and its
+project, [OCCTSwift Refactor (#377)](https://github.com/orgs/SecondMouseAU/projects/2).
+
+**Keep the board's `Status` current where one exists — treat it as part of finishing the work, not
+a separate chore.** Update `Status` at the same points the workflow already visits: starting work
+on the issue moves the card to `In Progress`, opening a PR moves it to `PR Review`, a review
+landing moves it to `Code-Review`. An agent picking up a board-tracked issue moves it to
+`In Progress` itself at the start of that work, not after. For an initiative staged through its own
+integration branch rather than merging straight to the default branch, a merged PR is `Code-Review`,
+not `Done` — reserve `Done` for the point the initiative's branch itself reaches the default
+branch, and don't wire the project's native "Item closed"/"PR merged" → `Done` automations for that
+shape of initiative, since both fire on the wrong event. See the full **Issue tracking** section of
+[OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md) for the
+detailed rationale, incident history, and a GitHub platform quirk around `Linked pull requests` not
+populating for non-default-branch PRs.
+
+Ecosystem standard: see
+[OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md).


### PR DESCRIPTION
<!--
Source of truth is the OKF bundle (okf/index.md). Ground this change in the relevant
policies / strategies / decisions and keep them current in THIS PR.
-->

## What & why

Adds `okf/policies/issue-tracking.md`, the 5th mandatory OKF policy (documented in
OKF-STANDARD.md since PR #27, never rolled out to this repo until now). Links it from
`okf/index.md`'s Policies list, and creates the `type:*` (bug/feature/chore/epic/spike/docs)
and `priority:*` (P0-P3) GitHub labels the policy requires.

Full policy text and rationale: https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md

Closes #

## Checklist

- [ ] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification) — see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.

N/A — documentation-only change (adds a policy doc + GitHub labels), no code behavior changed.

## Notes for the reviewer

Doc-only change; mirrors the wording already established for this policy in OKF-STANDARD.md
(PR #27) and being rolled out identically across the other OCCTSwift-family repos.