### PR TITLE
chore(#95): roll out the ecosystem code-style policy here

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,0 +1,71 @@
+name: code-style
+
+# Rollout of the ecosystem's code-style policy here (#95); see
+# docs/code-style-policy-proposal-2026-08.md in the `ecosystem` repo for the
+# full rationale, and okf/policies/code-style.md for this repo's own policy.
+#
+# Unlike the OCCTSwiftScripts pilot (small enough to fully sweep in one PR),
+# this repo carries 1,503 pre-existing swift-format diagnostics across
+# Sources/OCCTSwiftViewport (52 files) measured on rollout day, so this uses
+# gradual adoption, the same shape as OCCTSwift's own rollout (#876): a
+# checked-in exemption manifest (scripts/style-manifest-swift.txt)
+# grandfathers every file that existed at rollout, and
+# scripts/check-style-manifest.py enforces that touching a manifest file
+# means fixing it and removing it from the manifest in the same PR, not
+# leaving it exempt while edited.
+#
+# No first-party C++ bridge exists in this repo (pure Metal/SwiftUI viewport
+# library), so unlike OCCTSwift there's no clang-format step here.
+#
+# swift-format and SwiftLint are blocking for everything NOT on the manifest:
+# formatting has no judgment call in it once a file complies.
+# check-style-manifest.py is blocking (its whole job is catching a specific,
+# unambiguous rule violation).
+#
+# This repo has no CI at all today, so this workflow is bootstrapped from
+# nothing rather than added alongside an existing build-and-test lane. Pure
+# text analysis, no OCCT/Metal build needed, so a macOS runner is used only
+# for Homebrew availability of swift-format/swiftlint, not for compiling.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  code-style:
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      # fetch-depth: 0, not the default shallow clone: check-style-manifest.py
+      # diffs against origin/main's merge-base, which needs real history.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install swift-format, SwiftLint
+        run: brew install swift-format swiftlint
+
+      - name: swift-format lint --strict (files not on the exemption manifest)
+        run: |
+          comm -23 \
+            <(find Sources/OCCTSwiftViewport -name '*.swift' | sort) \
+            <(grep -v '^#' scripts/style-manifest-swift.txt | sort) \
+            | tr '\n' '\0' \
+            | xargs -0 swift-format lint --strict --configuration .swift-format
+
+      - name: swiftlint lint --strict
+        if: '!cancelled()'
+        run: swiftlint lint --strict --config .swiftlint.yml
+
+      - name: check-style-manifest.py --self-test
+        if: '!cancelled()'
+        run: python3 scripts/check-style-manifest.py --self-test
+
+      - name: check-style-manifest.py
+        if: '!cancelled()'
+        run: python3 scripts/check-style-manifest.py --base origin/main

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,75 @@
+{
+  "version" : 1,
+  "lineLength" : 100,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "tabWidth" : 4,
+  "maximumBlankLines" : 1,
+  "respectsExistingLineBreaks" : true,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineBreakBetweenDeclarationAttributes" : false,
+  "multiElementCollectionTrailingCommas" : true,
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "reflowMultilineStringLiterals" : "never",
+  "spacesAroundRangeFormationOperators" : false,
+  "spacesBeforeEndOfLineComments" : 2,
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "orderedImports" : {
+    "includeConditionalImports" : false
+  },
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AlwaysUseLiteralForEmptyCollectionInit" : false,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "AvoidRetroactiveConformances" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : true,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : false,
+    "NeverUseForceTry" : false,
+    "NeverUseImplicitlyUnwrappedOptionals" : false,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyLinesOpeningClosingBraces" : false,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : false,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : false,
+    "UseExplicitNilCheckInConditions" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : false,
+    "ValidateDocumentationComments" : true
+  }
+}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,37 @@
+# Deliberately narrow: `only_rules`, not `disabled_rules`. SwiftLint's default
+# rule set covers two kinds of territory this repo doesn't want it opining on:
+#
+#   - Layout (colon/comma/opening_brace/line_length/...): swift-format already
+#     owns this; running both fights, since they can disagree on the same line.
+#   - Code-quality/complexity (identifier_name, cyclomatic_complexity,
+#     function_body_length, nesting, type_body_length, file_length, ...), a
+#     separate concern from code style, and one that overlaps this repo's own
+#     code-structure policy (a file/type that needs a structural pass runs one
+#     as its own scoped initiative per that policy, not as a side effect of a
+#     style-lint gate).
+#
+# What's left is the one rule that catches something swift-format has no
+# equivalent for: a doc comment not attached to any declaration.
+#
+# See docs/code-style-policy-proposal-2026-08.md in the ecosystem repo for the
+# full rationale, and okf/policies/code-style.md for this repo's own policy.
+
+only_rules:
+  - orphaned_doc_comment
+
+excluded:
+  - .build
+  - .swiftpm
+  - build
+  - Tests
+  - Examples
+  - UITests
+  - Samples
+  - scripts
+  # One known, named, tracked orphaned-doc-comment finding (#96), not fixed in
+  # the rollout PR that added this rule: it's a module-level DocC-style doc
+  # comment (the file's own "Overview"/"Quick Start" documentation) rather
+  # than a comment accidentally separated from a declaration, and resolving
+  # it either way is a real documentation-structure decision, not a
+  # mechanical move. Remove this line once #96 lands.
+  - Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift

--- a/okf/index.md
+++ b/okf/index.md
@@ -49,3 +49,4 @@ changelog, the Swift Package Index page, and OpenCASCADE upstream.
 - [Search before building](policies/search-before-building.md)
 - [Code structure](policies/code-structure.md)
 - [Issue labels and project-board tracking](policies/issue-tracking.md)
+- [Code style](policies/code-style.md)

--- a/okf/policies/code-style.md
+++ b/okf/policies/code-style.md
@@ -1,0 +1,69 @@
+---
+type: policy
+title: Code style
+description: Swift naming/API shape follows the Swift API Design Guidelines, formatting follows Google's Swift Style Guide via swift-format; docs/ is the single source of truth for design rationale, not a second copy of it. Rolled out gradually via an exemption manifest, not a big-bang sweep.
+tags: [policy, style, swift, docs, agents]
+timestamp: 2026-08-12
+---
+
+# Code style
+
+**Naming and API shape** follow the
+[Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/) as-is.
+
+**Swift formatting** follows [Google's Swift Style Guide](https://google.github.io/swift/),
+enforced by `swift-format` (`.swift-format`: 100-column limit, 4-space indent, the ecosystem's
+one deliberate divergence from Google's own 2-space default, chosen to avoid a repo-wide reformat
+diff with no readability gain).
+
+**No first-party C++ bridge exists in this repo.** `OCCTSwiftViewport` is a pure Metal/SwiftUI
+viewport library with no OCCT dependency (see `okf/index.md`), so unlike `OCCTSwift`'s
+`OCCTBridge` layer, there's no `clang-format` half to this policy here.
+
+**SwiftLint is scoped to `orphaned_doc_comment` only** (`.swiftlint.yml`, `only_rules`, not the
+default set). SwiftLint's defaults duplicate `swift-format`'s formatting opinions (can disagree
+with them on the same line) and separately add a large code-quality/complexity surface
+(`identifier_name`, `cyclomatic_complexity`, `function_body_length`, `nesting`, ...) that overlaps
+[code-structure](code-structure.md) rather than this policy; a file that needs a structural pass
+runs one as its own scoped initiative, not as a side effect of a style-lint gate.
+`orphaned_doc_comment` catches something `swift-format` has no equivalent for, and found one real
+finding on rollout day: a 63-line module-overview doc comment in `OCCTSwiftViewport.swift`
+(possibly a deliberate DocC landing-page convention rather than a bug, since the file is named
+after the module) not attached to any single declaration. Tracked as
+[#96](https://github.com/SecondMouseAU/OCCTSwiftViewport/issues/96) rather than resolved inline,
+since either fix (attaching it to a declaration, or trimming it toward `docs/` per this policy's
+own single-source-of-truth rule below) is a real documentation-structure decision, not a
+mechanical move. The file is named in `.swiftlint.yml`'s `excluded:` list until #96 lands.
+
+**Doc comments stay terse.** A `///` comment is a single-sentence summary plus only the
+`Parameter`/`Returns`/`Throws` tags that add something the summary doesn't already say. Design
+rationale, extended examples, and issue cross-references belong in `docs/`, not duplicated in
+source: `docs/` is the single source of truth for *why* and *how*, per
+[GitLab's documentation style guide](https://docs.gitlab.com/development/documentation/styleguide/)
+("share the link to the documentation instead of rephrasing the information").
+
+## Gradual rollout: the exemption manifest, not a big-bang sweep
+
+Unlike the ecosystem's pilot repo (`OCCTSwiftScripts`, small enough to sweep into full compliance
+in one PR), this repo measured 1,503 pre-existing `swift-format` diagnostics across
+`Sources/OCCTSwiftViewport` (52 files) on rollout day, so it uses the same gradual approach
+`OCCTSwift` established:
+
+- `scripts/style-manifest-swift.txt` lists every file that existed at rollout. A listed file is
+  exempt from `swift-format` until touched.
+- **If you touch a listed file, you fix it and remove it from the manifest in the same PR.**
+  `scripts/check-style-manifest.py` (copied verbatim from `OCCTSwift`, including its fix for a
+  seeding-vs-growing bug found via testing against real git history) enforces this mechanically:
+  a manifest file appearing in a PR's diff while still listed at `HEAD` fails the build.
+- The manifest only shrinks. A new file is never grandfathered onto it; new code complies from
+  creation, checked by the same `swift-format`/SwiftLint steps running unconditionally against
+  anything not already listed.
+
+Why: the ecosystem-wide proposal and evidence live in
+[`ecosystem` docs/code-style-policy-proposal-2026-08.md](https://github.com/SecondMouseAU/ecosystem/blob/main/docs/code-style-policy-proposal-2026-08.md).
+Rollout sequencing (the OCCTMCP cluster, then `OCCTSwiftMesh`/`OCCTSwiftViewport`) is in that
+document's §4. Filed and tracked as
+[OCCTSwiftViewport#95](https://github.com/SecondMouseAU/OCCTSwiftViewport/issues/95).
+
+Ecosystem standard: see
+[OKF-STANDARD.md](https://github.com/SecondMouseAU/ecosystem/blob/main/OKF-STANDARD.md).

--- a/scripts/check-style-manifest.py
+++ b/scripts/check-style-manifest.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Enforce "if you touch a legacy file, you fix it" for the code-style rollout (#95).
+
+Ported verbatim from OCCTSwift's already-debugged version (#876/PR #878), including its
+fix for a real seeding-vs-growing bug found via testing against real git history (see
+`read_manifest_at`'s docstring below). Only the manifest path list and this header are
+adapted for this repo: no C++ bridge here (pure Metal/SwiftUI viewport library, no OCCT
+dependency), so there's a single manifest, not two, and this repo's own `scripts/`
+directory is lowercase (matching its pre-existing `scripts/overnight-stress.sh`), unlike
+OCCTSwift's capitalized `Scripts/`.
+
+A whole-tree zero-tolerance swift-format/SwiftLint gate would fail every PR against the
+1,503 pre-existing swift-format diagnostics already measured across
+Sources/OCCTSwiftViewport (52 files, none of which has ever been run through the tool).
+Forcing a big-bang fix before any gate can turn on is the outcome the ecosystem's
+rollout plan explicitly rejects in favor of gradual adoption: fix what you touch, not
+the whole tree at once.
+
+One manifest file holds the exemption list, seeded once on rollout day with every file
+that existed then:
+  - scripts/style-manifest-swift.txt   (Sources/OCCTSwiftViewport/*.swift)
+
+The rule, checked against the PR's diff relative to a base ref (`origin/main` by
+default):
+  1. A file NOT on the manifest must already be clean (checked separately, by the
+     normal swift-format/swiftlint gate steps -- this script doesn't re-run those
+     tools, it only enforces the manifest's own bookkeeping).
+  2. A file ON the manifest that appears in the diff must be REMOVED from it in the
+     same PR. Leaving it listed while touching it is exactly what this script exists
+     to catch -- "touched a legacy file, left it on the exemption list" is a silent
+     failure to comply, not a clean pass.
+  3. The manifest may only shrink. Comparing HEAD's manifest against the base ref's,
+     any entry present at HEAD but absent at the base is a new grandfather-listing,
+     which this policy doesn't allow: everything new complies from creation.
+
+Usage:
+  scripts/check-style-manifest.py                # compares against origin/main
+  scripts/check-style-manifest.py --base <ref>
+  scripts/check-style-manifest.py --self-test
+"""
+import argparse
+import subprocess
+import sys
+
+MANIFESTS = [
+    'scripts/style-manifest-swift.txt',
+]
+
+
+def run(args):
+    return subprocess.run(args, capture_output=True, text=True, check=False)
+
+
+def read_manifest_at(ref, path):
+    """The manifest's contents at `ref` ('' for the working tree), as a set of paths,
+    or None if the file doesn't exist at that ref.
+
+    None vs. an empty set matters: a manifest that doesn't exist yet at the base ref is
+    being seeded by this PR (fine, not a shrink violation); a manifest that exists and
+    is empty has genuinely had every entry removed (also fine, same reason). Collapsing
+    the two to "empty set" is exactly the bug this distinction exists to avoid -- it's
+    what made this script fail against its own seeding PR on first real-git-history run
+    (#876), since every entry in a brand-new manifest read as "newly added" relative to
+    a base where the file didn't exist at all.
+    """
+    if ref == '':
+        try:
+            with open(path, encoding='utf-8') as fh:
+                lines = fh.read().splitlines()
+        except FileNotFoundError:
+            return None
+    else:
+        result = run(['git', 'show', f'{ref}:{path}'])
+        if result.returncode != 0:
+            return None
+        lines = result.stdout.splitlines()
+    return {line.strip() for line in lines if line.strip() and not line.strip().startswith('#')}
+
+
+def diff_files(base):
+    result = run(['git', 'diff', '--name-only', f'{base}...HEAD'])
+    if result.returncode != 0:
+        print(f'FAIL: git diff against {base} failed: {result.stderr.strip()}', file=sys.stderr)
+        sys.exit(2)
+    return set(result.stdout.splitlines())
+
+
+def check(manifest_path, base, changed):
+    """Pure logic: given one manifest's base/HEAD contents and the PR's changed-file
+    set, return (touched_but_not_removed, newly_added). Both should be empty to pass.
+    """
+    base_entries = read_manifest_at(base, manifest_path)
+    head_entries = read_manifest_at('', manifest_path) or set()
+
+    touched_but_not_removed = sorted(head_entries & changed)
+    # base_entries is None exactly when the manifest doesn't exist at the base ref yet:
+    # this PR is seeding it, not growing an existing one. Nothing to compare against,
+    # so nothing counts as "newly added" -- see read_manifest_at's own docstring.
+    newly_added = [] if base_entries is None else sorted(head_entries - base_entries)
+    return touched_but_not_removed, newly_added
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--base', default='origin/main', help='ref to diff against (default: origin/main)')
+    ap.add_argument('--self-test', action='store_true')
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    changed = diff_files(args.base)
+    fail = False
+    for manifest_path in MANIFESTS:
+        touched, added = check(manifest_path, args.base, changed)
+        if touched:
+            fail = True
+            print(f'FAIL: {manifest_path} still lists {len(touched)} file(s) this PR touches:')
+            for f in touched:
+                print(f'  {f}')
+            print('  Bring each into compliance (swift-format/swiftlint clean) '
+                  'and remove it from the manifest in this same PR.')
+        if added:
+            fail = True
+            print(f'FAIL: {manifest_path} grew by {len(added)} entr{"y" if len(added) == 1 else "ies"} '
+                  f'not present at {args.base}:')
+            for f in added:
+                print(f'  {f}')
+            print('  New files comply from creation; they do not get grandfathered onto the manifest.')
+
+    if not fail:
+        print(f'check-style-manifest: clean against {args.base}')
+    return 1 if fail else 0
+
+
+def self_test():
+    """Exercise check() against synthetic manifest snapshots, no real git repo needed."""
+    import unittest.mock as mock
+
+    cases = [
+        ('untouched legacy file, left alone',
+         {'A.swift', 'B.swift'}, {'A.swift', 'B.swift'}, set(),
+         [], []),
+        ('legacy file touched and removed from the manifest (the compliant fix)',
+         {'A.swift', 'B.swift'}, {'B.swift'}, {'A.swift'},
+         [], []),
+        ('legacy file touched, left on the manifest (the violation this script exists for)',
+         {'A.swift', 'B.swift'}, {'A.swift', 'B.swift'}, {'A.swift'},
+         ['A.swift'], []),
+        ('new file grandfathered onto the manifest (not allowed)',
+         {'A.swift'}, {'A.swift', 'C.swift'}, set(),
+         [], ['C.swift']),
+        ('both violations at once',
+         {'A.swift', 'B.swift'}, {'A.swift', 'B.swift', 'C.swift'}, {'A.swift'},
+         ['A.swift'], ['C.swift']),
+        ('manifest does not exist at base: this PR is seeding it, not growing it (#876)',
+         None, {'A.swift', 'B.swift', 'C.swift'}, set(),
+         [], []),
+    ]
+
+    failed = 0
+    for name, base_set, head_set, changed, want_touched, want_added in cases:
+        with mock.patch.object(sys.modules[__name__], 'read_manifest_at',
+                                side_effect=lambda ref, path, b=base_set, h=head_set:
+                                h if ref == '' else b):
+            touched, added = check('fake-manifest.txt', 'fake-base', changed)
+        ok = touched == want_touched and added == want_added
+        failed += not ok
+        print(f'  {"ok  " if ok else "MISS"} {name}: touched={touched} added={added}')
+
+    print(f'{len(cases) - failed}/{len(cases)} cases correct')
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    import os
+    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+    sys.exit(main())

--- a/scripts/style-manifest-swift.txt
+++ b/scripts/style-manifest-swift.txt
@@ -1,0 +1,57 @@
+# Exemption manifest for the code-style rollout (#95).
+# Seeded 2026-08-12 with every Sources/OCCTSwiftViewport/*.swift file that existed at
+# that point. A file is removed from this list once it's brought into full
+# swift-format/swiftlint compliance; touching a listed file without removing it
+# fails scripts/check-style-manifest.py. See okf/policies/code-style.md.
+Sources/OCCTSwiftViewport/Camera/CameraController.swift
+Sources/OCCTSwiftViewport/Camera/CameraState.swift
+Sources/OCCTSwiftViewport/Camera/CameraState+ClipPlanes.swift
+Sources/OCCTSwiftViewport/Camera/PivotStrategy.swift
+Sources/OCCTSwiftViewport/Camera/RotationStyle.swift
+Sources/OCCTSwiftViewport/Camera/StandardView.swift
+Sources/OCCTSwiftViewport/Configuration/ClipPlane.swift
+Sources/OCCTSwiftViewport/Configuration/GestureConfiguration.swift
+Sources/OCCTSwiftViewport/Configuration/MaterialLibrary.swift
+Sources/OCCTSwiftViewport/Configuration/PBRMaterial.swift
+Sources/OCCTSwiftViewport/Configuration/ViewportConfiguration.swift
+Sources/OCCTSwiftViewport/Display/DisplayMode.swift
+Sources/OCCTSwiftViewport/Display/LightingConfiguration.swift
+Sources/OCCTSwiftViewport/HUD/CameraScale.swift
+Sources/OCCTSwiftViewport/HUD/OrientationGnomon.swift
+Sources/OCCTSwiftViewport/HUD/ScaleBarView.swift
+Sources/OCCTSwiftViewport/Input/ViewportInputEvent.swift
+Sources/OCCTSwiftViewport/Input/ViewportInputRouter.swift
+Sources/OCCTSwiftViewport/Input/ViewportModifierKeys.swift
+Sources/OCCTSwiftViewport/Math/BoundingBox.swift
+Sources/OCCTSwiftViewport/Math/Frustum.swift
+Sources/OCCTSwiftViewport/Math/MatrixUtils.swift
+Sources/OCCTSwiftViewport/Math/ProjectionUtility.swift
+Sources/OCCTSwiftViewport/Math/Ray.swift
+Sources/OCCTSwiftViewport/Math/SceneRaycast.swift
+Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift
+Sources/OCCTSwiftViewport/Picking/MeasurementPicking.swift
+Sources/OCCTSwiftViewport/Picking/PickingConfiguration.swift
+Sources/OCCTSwiftViewport/Picking/PickResult.swift
+Sources/OCCTSwiftViewport/Picking/PickTextureManager.swift
+Sources/OCCTSwiftViewport/Picking/SelectionFilter.swift
+Sources/OCCTSwiftViewport/Renderer/EnvironmentMapManager.swift
+Sources/OCCTSwiftViewport/Renderer/HDRLoader.swift
+Sources/OCCTSwiftViewport/Renderer/MeasurementCompositor.swift
+Sources/OCCTSwiftViewport/Renderer/MeshletBuilder.swift
+Sources/OCCTSwiftViewport/Renderer/MetalViewRepresentable.swift
+Sources/OCCTSwiftViewport/Renderer/NormalSmoothing.swift
+Sources/OCCTSwiftViewport/Renderer/OffscreenRenderer.swift
+Sources/OCCTSwiftViewport/Renderer/Primitives.swift
+Sources/OCCTSwiftViewport/Renderer/ShadowMapManager.swift
+Sources/OCCTSwiftViewport/Renderer/TessellationManager.swift
+Sources/OCCTSwiftViewport/Renderer/ViewportRenderer.swift
+Sources/OCCTSwiftViewport/Types/Measurement.swift
+Sources/OCCTSwiftViewport/Types/ViewportArc.swift
+Sources/OCCTSwiftViewport/Types/ViewportBody.swift
+Sources/OCCTSwiftViewport/ViewCube/NavigationCube.swift
+Sources/OCCTSwiftViewport/ViewCube/NavigationCubeView.swift
+Sources/OCCTSwiftViewport/ViewCube/ViewCubeRegion.swift
+Sources/OCCTSwiftViewport/ViewCube/ViewCubeView.swift
+Sources/OCCTSwiftViewport/Views/MeasurementOverlay.swift
+Sources/OCCTSwiftViewport/Views/MetalViewportView.swift
+Sources/OCCTSwiftViewport/Views/ViewportController.swift


### PR DESCRIPTION
## What & why

Rolls out the ecosystem's code-style policy
([`ecosystem` docs/code-style-policy-proposal-2026-08.md](https://github.com/SecondMouseAU/ecosystem/blob/main/docs/code-style-policy-proposal-2026-08.md))
here, following `OCCTSwift`'s own gradual rollout
([#876](https://github.com/SecondMouseAU/OCCTSwift/issues/876)/[PR #878](https://github.com/SecondMouseAU/OCCTSwift/pull/878))
rather than the `OCCTSwiftScripts` full-sweep pilot ([#114](https://github.com/SecondMouseAU/OCCTSwiftScripts/issues/114)/[PR #115](https://github.com/SecondMouseAU/OCCTSwiftScripts/pull/115)).

**Why gradual manifest, not a full sweep.** Measured on rollout day: `Sources/OCCTSwiftViewport`
has 52 Swift files, and `swift-format lint --strict` against them (once `.swift-format` existed)
found **1,503 pre-existing diagnostics**:

```
$ find Sources/OCCTSwiftViewport -name '*.swift' -print0 | xargs -0 swift-format lint --strict --configuration .swift-format
... (1503 lines of diagnostics)
$ echo $?
1
```

A whole-tree zero-tolerance gate would fail every PR against work nobody touched, so this uses
the same exemption-manifest mechanism `OCCTSwift` proved out, not a big-bang reformat.

**Note on repo scale vs. the plan's assumption.** The rollout plan characterized this repo as
"LARGE (comparable in scale to what OCCTSwift itself was before its refactor)" at ~211 files /
~52,080 lines. Measured directly during this rollout: `Sources/OCCTSwiftViewport` is 52 files /
12,946 lines (that 52,080-line figure appears to reflect the whole working tree including
`Examples/`, `Tests/`, and vendored `build/` SPM checkouts of sibling repos, not this package's
own `Sources/`). That's roughly the same scale as the `OCCTSwiftScripts` full-sweep pilot (48
files / ~10.7k lines), not `OCCTSwift`'s scale (222 files, ~11,700 diagnostics). The 1,503 real
diagnostics measured above are genuine and non-trivial, though, so the gradual-manifest approach
is still the right, conservative choice here even at this smaller scale (per the task's explicit
direction to use it, not a sweep) — flagging the size discrepancy for visibility, not proposing a
scope change in this PR.

## What's added

- `.swift-format` (100 col, 4-space, copied verbatim from `OCCTSwift`'s already-tuned config).
- `.swiftlint.yml` (`only_rules: [orphaned_doc_comment]`, same narrow scoping as both precedent
  repos, for the same reason: SwiftLint's defaults duplicate `swift-format`'s formatting opinions
  and separately open a code-quality/complexity surface that belongs to `code-structure`, not
  this policy).
- `scripts/check-style-manifest.py`, ported from `OCCTSwift`'s already-debugged version verbatim
  (including its fix for a real seeding-vs-growing bug found via testing against real git
  history: a brand-new manifest's entries must not read as "newly added" relative to a base ref
  where the file doesn't exist at all). Only the manifest-path constant and header comment are
  repo-adapted: this repo has one manifest (no C++ bridge), and its own `scripts/` directory is
  lowercase (matching the pre-existing `scripts/overnight-stress.sh`), unlike `OCCTSwift`'s
  capitalized `Scripts/`. Everything else, including every function body, is unchanged.
- `scripts/style-manifest-swift.txt`, seeded with all 52 current `Sources/OCCTSwiftViewport/*.swift`
  files.
- `.github/workflows/code-style.yml`, **bootstrapped from nothing** (this repo had no CI at all
  before this PR): macOS runner, `brew install swift-format swiftlint`, `fetch-depth: 0` for the
  manifest diff check, `swift-format`/`swiftlint` blocking on non-manifest files via `comm -23`,
  `check-style-manifest.py` blocking. No `clang-format` step, matching the next point.
- `okf/policies/code-style.md`, linked from `okf/index.md`.

**Explicitly out of scope, confirmed directly:** no first-party C++ bridge exists in this repo
(pure Metal/SwiftUI viewport library, no OCCT dependency per its own `okf/index.md`). Confirmed
via a repo-wide search excluding vendored build artifacts:

```
$ find . \( -iname "*.cpp" -o -iname "*.mm" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.cc" -o -iname "*.c" \) \
    -not -path "./.build/*" -not -path "*/.build/*" -not -path "./build/*" -not -path "./.swiftpm/*"
(no output)
```

## A real finding, handled per the OCCTSwift #877 precedent

`SwiftLint`'s `orphaned_doc_comment` found **one genuine finding**:
`Sources/OCCTSwiftViewport/OCCTSwiftViewport.swift:7` — a 63-line `///` doc comment (the module's
"Overview"/"Quick Start"/"Camera Control" documentation) sits at the top of the file, followed by
`// MARK: - Public API` and ~75 `public typealias` re-exports, not directly attached to any one
declaration.

Unlike `OCCTSwift`'s two findings (#877), this file has **zero pre-existing `swift-format`
diagnostics** already, so fixing it wouldn't trigger a forced reformat under the manifest rule.
It's still not fixed inline: the file is named after the module
(`OCCTSwiftViewport.swift`/`OCCTSwiftViewport`), so this may be a deliberate DocC
module-landing-page convention rather than a drift bug, and it's also plausibly exactly the kind
of module-level restatement the new policy's own single-source-of-truth rule (§2c) asks to trim
toward `docs/`/`README.md` instead. Either resolution is a real documentation-structure decision,
not a mechanical move, so it's tracked separately as
[#96](https://github.com/SecondMouseAU/OCCTSwiftViewport/issues/96) rather than decided
unilaterally in a CI-infrastructure PR. The file is named in `.swiftlint.yml`'s `excluded:` list
until #96 lands.

## Zero behavior change. Verified directly, not just asserted

```
$ swift-format lint --strict on files NOT on the manifest (i.e. all of Sources, since the
  manifest was seeded with every current file):
$ comm -23 <(find Sources/OCCTSwiftViewport -name '*.swift' | sort) \
           <(grep -v '^#' scripts/style-manifest-swift.txt | sort) | xargs -0 -r ...
exit: 0   (empty set — every file is grandfathered, none outside the manifest)

$ swiftlint lint --strict --config .swiftlint.yml
Done linting! Found 0 violations, 0 serious in 52 files.
exit: 0

$ python3 scripts/check-style-manifest.py --self-test
6/6 cases correct
exit: 0

$ python3 scripts/check-style-manifest.py --base origin/main   (after pushing this branch)
check-style-manifest: clean against origin/main
exit: 0

$ swift build
Build complete! (50.36s)

$ swift test
Test run with 194 tests in 37 suites passed after 6.253 seconds.
```

No public API, source logic, or `Package.resolved` changed; tooling/CI/docs only. Confirmed
`git status` shows no `Package.resolved` diff anywhere in the repo before or after these local
build/test runs.

## Notes for the reviewer

- Per the ecosystem's own gate (no repo implements without a filed issue first), this was filed
  as [#95](https://github.com/SecondMouseAU/OCCTSwiftViewport/issues/95) before any of this
  landed.
- The two pre-existing untracked items noted in the task (`Examples/MetalDemo/Package.resolved`,
  `debug/`) are untouched, not staged, not committed.
- **Held for review, not to be merged.**

## Checklist

- [x] New or changed behavior is covered by a unit test in the same PR (not just manual
      verification); see [SecondMouseAU/OCCTReconstruct#397](https://github.com/SecondMouseAU/OCCTReconstruct/issues/397)
      for the ecosystem-wide test-coverage standard this is piloting.
      — N/A here: no behavior changed (CI/tooling/docs only), verified via `check-style-manifest.py --self-test`
      (6/6, ported from `OCCTSwift`'s own proven self-test) and the existing `swift test` suite (194/194) rather
      than new tests, since there's no new runtime behavior for a new test to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
